### PR TITLE
Update EKS orb references

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ orb_promotion_filters: &orb_promotion_filters
     only: /^(major|minor|patch)-release-v\d+\.\d+\.\d+$/
 
 orbs:
-  aws-eks: circleci/aws-eks@0.2.0
+  aws-eks: circleci/aws-eks@0.2.1
   cli: circleci/circleci-cli@0.1.2
   helm: circleci/helm@dev:alpha
   kubernetes: circleci/kubernetes@0.2.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ orb_promotion_filters: &orb_promotion_filters
     only: /^(major|minor|patch)-release-v\d+\.\d+\.\d+$/
 
 orbs:
-  aws-eks: circleci/aws-eks@dev:alpha
+  aws-eks: circleci/aws-eks@0.2.0
   cli: circleci/circleci-cli@0.1.2
   helm: circleci/helm@dev:alpha
   kubernetes: circleci/kubernetes@0.2.0

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ See the [orb registry listing](http://circleci.com/orbs/registry/orb/circleci/he
 version: 2.1
 
 orbs:
-  aws-eks: circleci/aws-eks@0.1.0
+  aws-eks: circleci/aws-eks@0.2.1
   helm: circleci/helm@0.1.1
 
 jobs:

--- a/src/examples/install-helm-chart.yml
+++ b/src/examples/install-helm-chart.yml
@@ -5,7 +5,7 @@ usage:
   version: 2.1
 
   orbs:
-    aws-eks: circleci/aws-eks@0.1.0
+    aws-eks: circleci/aws-eks@0.2.1
     helm: circleci/helm@0.1.1
 
   jobs:


### PR DESCRIPTION
Update EKS orb references in the orb's examples, as well as in the readme and build for this project.
The 0.1.0 version of the EKS orb does not work well after an update to the underlying eksctl tool used.