### PR TITLE
Ensure v2 is default

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -2,7 +2,9 @@ version: 2.1
 
 description: |
   An orb for working with helm for Kubernetes deployments.
-  Project homepage: https://github.com/CircleCI-Public/helm-orb
+
+display:
+  home_url: https://github.com/CircleCI-Public/helm-orb
 
 orbs:
   kubernetes: circleci/kubernetes@0.2.0

--- a/src/commands/install-helm-client.yml
+++ b/src/commands/install-helm-client.yml
@@ -1,6 +1,6 @@
 description: |
   Install the helm client.
-  Defaults to the latest version of Helm 2. 
+  Defaults to the latest version of Helm 2.
 
   Requirements: curl
 

--- a/src/commands/install-helm-client.yml
+++ b/src/commands/install-helm-client.yml
@@ -1,12 +1,13 @@
 description: |
-  Install the helm client
+  Install the helm client.
+  Defaults to the latest version of Helm 2. 
 
   Requirements: curl
 
 parameters:
   version:
     type: string
-    default: ""
+    default: "v2.16.1"
     description: the helm client version to install. e.g. v2.4.0
 
 steps:


### PR DESCRIPTION
Enforce helm v2 as the default to be installed when no version parameter is specified
Add home_url