### PR TITLE
Skip helm init if not v2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,6 +171,10 @@ workflows:
       - helm-client-install-test:
           name: helm-client-install-latest
           filters: *integration_test_filters
+      - helm-client-install-test:
+          name: helm-client-install-v3
+          version: v3.0.0
+          filters: *integration_test_filters
       - aws-eks/create-cluster:
           cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-helm-eks
           filters: *integration_test_filters

--- a/src/commands/install-helm-client.yml
+++ b/src/commands/install-helm-client.yml
@@ -1,6 +1,7 @@
 description: |
   Install the helm client.
   Defaults to the latest version of Helm 2.
+  To use Helm 3, specify a version e.g. "v3.0.0".
 
   Requirements: curl
 
@@ -19,11 +20,17 @@ steps:
           exit 0
         fi
         VERSION="<< parameters.version >>"
+        IS_VERSION_2="true"
         if [ -n "${VERSION}" ]; then
           set -- "$@" --version "${VERSION}"
+          if [ "${VERSION}" == "${VERSION#v2.}" ]; then
+            IS_VERSION_2="false"
+          fi
         fi
         INSTALL_SCRIPT="https://raw.githubusercontent.com/helm/helm/master/scripts/get"
         curl "${INSTALL_SCRIPT}" > get_helm.sh
         chmod 700 get_helm.sh
         ./get_helm.sh "$@"
-        helm init --client-only
+        if [ "${IS_VERSION_2}" == "true" ]; then
+          helm init --client-only
+        fi

--- a/src/commands/install-helm-client.yml
+++ b/src/commands/install-helm-client.yml
@@ -13,7 +13,7 @@ parameters:
 
 steps:
   - run:
-      name: Install and init the helm client
+      name: Install and init the helm client (if necessary)
       command: |
         if which helm > /dev/null; then
           echo "helm is already installed"

--- a/src/commands/install-helm-on-cluster.yml
+++ b/src/commands/install-helm-on-cluster.yml
@@ -1,5 +1,7 @@
 description: |
-  Install helm into an existing Kubernetes cluster.
+  Install helm 2 into an existing Kubernetes cluster.
+  (This command is not compatible with helm 3 which does not have a
+  Tiller component)
   Note: Parameters like tiller-tls need to be set to
   apply security configurations to the tiller configuration.
 


### PR DESCRIPTION
- Do not execute `helm init` if version of helm used is not v2, to address https://github.com/CircleCI-Public/helm-orb/issues/15
- Clarify `install-helm-on-cluster` command - only meant for v2
