### PR TITLE
fix wrong typo on reuse-values option for helm upgrade command

### DIFF
--- a/src/commands/upgrade-helm-chart.yml
+++ b/src/commands/upgrade-helm-chart.yml
@@ -190,10 +190,10 @@ steps:
           set -- "$@" --dry-run
         fi
         if [ "${RESET_VALUES}" == "true" ]; then
-          set -- "$@" --reset_values
+          set -- "$@" --reset-values
         fi
         if [ "${REUSE_VALUES}" == "true" ]; then
-          set -- "$@" --reuse_values
+          set -- "$@" --reuse-values
         fi
         if [ -n "${VALUES}" ]; then
           set -- "$@" --values "${VALUES}"


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

The `reuse-values` and `reset-values`  options for the command `upgrade-helm-chart` have a wrong typo and do not currently work. This PR is here to fix it.
