### PR TITLE
 Conditionally disable updating repositories

### DIFF
--- a/src/commands/install-helm-chart.yml
+++ b/src/commands/install-helm-chart.yml
@@ -68,13 +68,21 @@ parameters:
       Whether to wait for the installation to be complete
     type: boolean
     default: true
+  update-repositories:
+    description: |
+      Choose to update repositories by running helm repo update.
+    type: boolean
+    default: true
 
 steps:
   - install-helm-client
-  - run:
-      name: Update repository
-      command: |
-        helm repo update
+  - when:
+    condition: << parameters.update-repositories >>
+    steps:
+      - run:
+          name: Update repositories
+          command: |
+            helm repo update
   - run:
       name: Install chart
       command: |

--- a/src/commands/upgrade-helm-chart.yml
+++ b/src/commands/upgrade-helm-chart.yml
@@ -119,12 +119,20 @@ parameters:
       command. Format: key1=val1,key2=val2
     type: string
     default: ""
+  update-repositories:
+    description: |
+      Choose to update repositories by running helm repo update.
+    type: boolean
+    default: true
 steps:
   - install-helm-client
-  - run:
-      name: Update repository
-      command: |
-        helm repo update
+  - when:
+    condition: << parameters.update-repositories >>
+    steps:
+      - run:
+          name: Update repositories
+          command: |
+            helm repo update
   - run:
       name: Upgrade or install chart
       command: |


### PR DESCRIPTION
by setting `update-repositories` to `false` when running `install-helm-chart` or `upgrade-helm-client`

### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [X] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues
Helm v3 doesn't include repositories by default [link to relevant issue](https://github.com/CircleCI-Public/helm-orb/issues/18). 
In my use case I don't really care for using remote repositories and would be happy to have a way to disable the step.

### Description

This PR adds an additional parameter `update-repositories` defaulting to `true` so that users can conditionally disable the `helm repo update` command.