### PR TITLE
Improve helm 3 compatibility [semver:major]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,6 +106,9 @@ jobs:
         type: string
         default: "v2.16.1"
         description: the helm client version to install. e.g. v2.4.0
+      timeout:
+        type: string
+        default: ""
     steps:
       - aws-eks/update-kubeconfig-with-authenticator:
           cluster-name: << parameters.cluster-name >>
@@ -113,7 +116,7 @@ jobs:
       - helm/delete-helm-release:
           release-name: grafana-release
           purge: true
-          timeout: 600
+          timeout: << parameters.timeout >>
           helm-version: << parameters.helm-version >>
   pre-orb-promotion-check:
     executor: aws-eks/python2
@@ -271,6 +274,15 @@ workflows:
           requires:
             - delete-helm-release-on-eks-cluster-helm3
           filters: *integration_test_filters
+      - delete-helm-release-on-eks-cluster:
+          name: delete-helm-release-on-eks-cluster-again-helm3
+          helm-version: v3.0.0
+          cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-helm3-eks
+          # test timeout
+          timeout: "600s"
+          requires:
+            - reinstall-helm-chart-on-eks-cluster-helm3
+          filters: *integration_test_filters
       - aws-eks/delete-cluster:
           name: delete-cluster-helm2
           cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-helm-eks
@@ -283,7 +295,7 @@ workflows:
           cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-helm3-eks
           wait: true
           requires:
-            - reinstall-helm-chart-on-eks-cluster-helm3
+            - delete-helm-release-on-eks-cluster-again-helm3
           filters: *integration_test_filters
   # Tag-triggered workflow to promote a dev orb into production.
   # The tag is expected to have been applied manually.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,11 @@ jobs:
         type: string
         default: "v2.16.1"
         description: the helm client version to install. e.g. v2.4.0
+      update-repositories:
+        description: |
+          Choose to update repositories by running helm repo update.
+        type: boolean
+        default: true
     steps:
       - aws-eks/update-kubeconfig-with-authenticator:
           cluster-name: << parameters.cluster-name >>
@@ -61,6 +66,7 @@ jobs:
           chart: stable/grafana
           release-name: grafana-release
           helm-version: << parameters.helm-version >>
+          update-repositories: << parameters.update-repositories >>
   upgrade-helm-chart-on-eks-cluster:
     executor: aws-eks/python
     parameters:
@@ -71,6 +77,11 @@ jobs:
         type: string
         default: "v2.16.1"
         description: the helm client version to install. e.g. v2.4.0
+      update-repositories:
+        description: |
+          Choose to update repositories by running helm repo update.
+        type: boolean
+        default: true
     steps:
       - aws-eks/update-kubeconfig-with-authenticator:
           cluster-name: << parameters.cluster-name >>
@@ -79,6 +90,7 @@ jobs:
           chart: stable/grafana
           release-name: grafana-release
           helm-version: << parameters.helm-version >>
+          update-repositories: << parameters.update-repositories >>
   delete-helm-release-on-eks-cluster:
     executor: aws-eks/python
     parameters:
@@ -212,6 +224,7 @@ workflows:
       - install-helm-chart-on-eks-cluster:
           name: install-helm-chart-on-eks-cluster-helm3
           helm-version: v3.0.0
+          update-repositories: false
           cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-helm3-eks
           requires:
             - create-cluster-helm3
@@ -225,6 +238,7 @@ workflows:
       - upgrade-helm-chart-on-eks-cluster:
           name: upgrade-helm-chart-on-eks-cluster-helm3
           helm-version: v3.0.0
+          update-repositories: false
           cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-helm3-eks
           requires:
             - install-helm-chart-on-eks-cluster-helm3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,10 @@ jobs:
       cluster-name:
         type: string
         description: Cluster name
+      helm-version:
+        type: string
+        default: "v2.16.1"
+        description: the helm client version to install. e.g. v2.4.0
     steps:
       - aws-eks/update-kubeconfig-with-authenticator:
           cluster-name: << parameters.cluster-name >>
@@ -56,12 +60,17 @@ jobs:
       - helm/install-helm-chart:
           chart: stable/grafana
           release-name: grafana-release
+          helm-version: << parameters.helm-version >>
   upgrade-helm-chart-on-eks-cluster:
     executor: aws-eks/python
     parameters:
       cluster-name:
         type: string
         description: Cluster name
+      helm-version:
+        type: string
+        default: "v2.16.1"
+        description: the helm client version to install. e.g. v2.4.0
     steps:
       - aws-eks/update-kubeconfig-with-authenticator:
           cluster-name: << parameters.cluster-name >>
@@ -69,12 +78,17 @@ jobs:
       - helm/upgrade-helm-chart:
           chart: stable/grafana
           release-name: grafana-release
+          helm-version: << parameters.helm-version >>
   delete-helm-release-on-eks-cluster:
     executor: aws-eks/python
     parameters:
       cluster-name:
         type: string
         description: Cluster name
+      helm-version:
+        type: string
+        default: "v2.16.1"
+        description: the helm client version to install. e.g. v2.4.0
     steps:
       - aws-eks/update-kubeconfig-with-authenticator:
           cluster-name: << parameters.cluster-name >>
@@ -83,6 +97,7 @@ jobs:
           release-name: grafana-release
           purge: true
           timeout: 600
+          helm-version: << parameters.helm-version >>
   pre-orb-promotion-check:
     executor: aws-eks/python2
     steps:
@@ -176,33 +191,70 @@ workflows:
           version: v3.0.0
           filters: *integration_test_filters
       - aws-eks/create-cluster:
+          name: create-cluster-helm2
           cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-helm-eks
+          filters: *integration_test_filters
+      - aws-eks/create-cluster:
+          name: create-cluster-helm3
+          cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-helm3-eks
           filters: *integration_test_filters
       - install-helm-on-eks-cluster:
           cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-helm-eks
           requires:
-            - aws-eks/create-cluster
+            - create-cluster-helm2
           filters: *integration_test_filters
       - install-helm-chart-on-eks-cluster:
+          name: install-helm-chart-on-eks-cluster-helm2
           cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-helm-eks
           requires:
             - install-helm-on-eks-cluster
           filters: *integration_test_filters
+      - install-helm-chart-on-eks-cluster:
+          name: install-helm-chart-on-eks-cluster-helm3
+          helm-version: v3.0.0
+          cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-helm3-eks
+          requires:
+            - create-cluster-helm3
+          filters: *integration_test_filters
       - upgrade-helm-chart-on-eks-cluster:
+          name: upgrade-helm-chart-on-eks-cluster-helm2
           cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-helm-eks
           requires:
-            - install-helm-chart-on-eks-cluster
+            - install-helm-chart-on-eks-cluster-helm2
+          filters: *integration_test_filters
+      - upgrade-helm-chart-on-eks-cluster:
+          name: upgrade-helm-chart-on-eks-cluster-helm3
+          helm-version: v3.0.0
+          cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-helm3-eks
+          requires:
+            - install-helm-chart-on-eks-cluster-helm3
           filters: *integration_test_filters
       - delete-helm-release-on-eks-cluster:
+          name: delete-helm-release-on-eks-cluster-helm2
           cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-helm-eks
           requires:
-            - upgrade-helm-chart-on-eks-cluster
+            - upgrade-helm-chart-on-eks-cluster-helm2
+          filters: *integration_test_filters
+      - delete-helm-release-on-eks-cluster:
+          name: delete-helm-release-on-eks-cluster-helm3
+          helm-version: v3.0.0
+          cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-helm3-eks
+          requires:
+            - upgrade-helm-chart-on-eks-cluster-helm3
           filters: *integration_test_filters
       - aws-eks/delete-cluster:
+          name: delete-cluster-helm2
           cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-helm-eks
           wait: true
           requires:
-            - delete-helm-release-on-eks-cluster
+            - delete-helm-release-on-eks-cluster-helm2
+          filters: *integration_test_filters
+      - aws-eks/delete-cluster:
+          name: delete-cluster-helm3
+          cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-helm3-eks
+          wait: true
+          requires:
+            - delete-helm-release-on-eks-cluster-helm3
           filters: *integration_test_filters
   # Tag-triggered workflow to promote a dev orb into production.
   # The tag is expected to have been applied manually.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,7 +224,6 @@ workflows:
       - install-helm-chart-on-eks-cluster:
           name: install-helm-chart-on-eks-cluster-helm3
           helm-version: v3.0.0
-          update-repositories: false
           cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-helm3-eks
           requires:
             - create-cluster-helm3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,9 @@ jobs:
   install-helm-chart-on-eks-cluster:
     executor: aws-eks/python
     parameters:
+      release-name:
+        type: string
+        default: "grafana-release"
       cluster-name:
         type: string
         description: Cluster name
@@ -91,6 +94,8 @@ jobs:
           release-name: grafana-release
           helm-version: << parameters.helm-version >>
           update-repositories: << parameters.update-repositories >>
+          # test specifying no-output-timeout
+          no-output-timeout: 25m
   delete-helm-release-on-eks-cluster:
     executor: aws-eks/python
     parameters:
@@ -224,6 +229,8 @@ workflows:
       - install-helm-chart-on-eks-cluster:
           name: install-helm-chart-on-eks-cluster-helm3
           helm-version: v3.0.0
+          # test repo update
+          update-repositories: true
           cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-helm3-eks
           requires:
             - create-cluster-helm3
@@ -255,6 +262,15 @@ workflows:
           requires:
             - upgrade-helm-chart-on-eks-cluster-helm3
           filters: *integration_test_filters
+      - install-helm-chart-on-eks-cluster:
+          name: reinstall-helm-chart-on-eks-cluster-helm3
+          helm-version: v3.0.0
+          # Test auto-generated release name
+          release-name: ""
+          cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-helm3-eks
+          requires:
+            - delete-helm-release-on-eks-cluster-helm3
+          filters: *integration_test_filters
       - aws-eks/delete-cluster:
           name: delete-cluster-helm2
           cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-helm-eks
@@ -267,7 +283,7 @@ workflows:
           cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-helm3-eks
           wait: true
           requires:
-            - delete-helm-release-on-eks-cluster-helm3
+            - reinstall-helm-chart-on-eks-cluster-helm3
           filters: *integration_test_filters
   # Tag-triggered workflow to promote a dev orb into production.
   # The tag is expected to have been applied manually.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
         description: Cluster name
       helm-version:
         type: string
-        default: "v2.16.1"
+        default: "v2.16.9"
         description: the helm client version to install. e.g. v2.4.0
       update-repositories:
         description: |
@@ -78,7 +78,7 @@ jobs:
         description: Cluster name
       helm-version:
         type: string
-        default: "v2.16.1"
+        default: "v2.16.9"
         description: the helm client version to install. e.g. v2.4.0
       update-repositories:
         description: |
@@ -104,7 +104,7 @@ jobs:
         description: Cluster name
       helm-version:
         type: string
-        default: "v2.16.1"
+        default: "v2.16.9"
         description: the helm client version to install. e.g. v2.4.0
       timeout:
         type: string
@@ -231,7 +231,7 @@ workflows:
           filters: *integration_test_filters
       - install-helm-chart-on-eks-cluster:
           name: install-helm-chart-on-eks-cluster-helm3
-          helm-version: v3.0.0
+          helm-version: v3.2.4
           # test repo update
           update-repositories: true
           cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-helm3-eks
@@ -246,7 +246,7 @@ workflows:
           filters: *integration_test_filters
       - upgrade-helm-chart-on-eks-cluster:
           name: upgrade-helm-chart-on-eks-cluster-helm3
-          helm-version: v3.0.0
+          helm-version: v3.2.4
           update-repositories: false
           cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-helm3-eks
           requires:
@@ -260,14 +260,14 @@ workflows:
           filters: *integration_test_filters
       - delete-helm-release-on-eks-cluster:
           name: delete-helm-release-on-eks-cluster-helm3
-          helm-version: v3.0.0
+          helm-version: v3.2.4
           cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-helm3-eks
           requires:
             - upgrade-helm-chart-on-eks-cluster-helm3
           filters: *integration_test_filters
       - install-helm-chart-on-eks-cluster:
           name: reinstall-helm-chart-on-eks-cluster-helm3
-          helm-version: v3.0.0
+          helm-version: v3.2.4
           # Test auto-generated release name
           release-name: ""
           cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-helm3-eks
@@ -276,7 +276,7 @@ workflows:
           filters: *integration_test_filters
       - delete-helm-release-on-eks-cluster:
           name: delete-helm-release-on-eks-cluster-again-helm3
-          helm-version: v3.0.0
+          helm-version: v3.2.4
           cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-helm3-eks
           # test timeout
           timeout: "600s"

--- a/src/commands/delete-helm-release.yml
+++ b/src/commands/delete-helm-release.yml
@@ -28,11 +28,6 @@ parameters:
       be specified e.g. '300s'.
     type: string
     default: ""
-  timeout:
-    description: |
-      If timeout is reached, the release will be marked as FAILED.
-    type: string
-    default: ""
   namespace:
     description: |
       The kubernetes namespace that should be used.

--- a/src/commands/delete-helm-release.yml
+++ b/src/commands/delete-helm-release.yml
@@ -23,11 +23,16 @@ parameters:
     default: false
   timeout:
     description: |
-      Specify time in seconds to wait for any individual Kubernetes operation
-      (like Jobs for hooks)
-      A value of -1 will be ignored.
-    type: integer
-    default: -1
+      Specify a timeout value that will be passed as a --timeout argument
+      to the helm command. For helm 3, the unit of the duration must
+      be specified e.g. '300s'.
+    type: string
+    default: ""
+  timeout:
+    description: |
+      If timeout is reached, the release will be marked as FAILED.
+    type: string
+    default: ""
   namespace:
     description: |
       The kubernetes namespace that should be used.
@@ -99,7 +104,7 @@ steps:
         TLS_VERIFY="<< parameters.tls-verify >>"
         TILLER_NAMESPACE="<< parameters.tiller-namespace >>"
 
-        if [ "${TIMEOUT}" != "-1" ]; then
+        if [ -n "${TIMEOUT}" ]; then
           set -- "$@" --timeout="${TIMEOUT}"
         fi
         if [ -n "${NAMESPACE}" ]; then

--- a/src/commands/delete-helm-release.yml
+++ b/src/commands/delete-helm-release.yml
@@ -71,7 +71,7 @@ parameters:
     default: ""
   helm-version:
     type: string
-    default: "v2.16.1"
+    default: "v2.16.9"
     description: the helm client version to install. e.g. v2.4.0
   no-output-timeout:
     description: |

--- a/src/commands/delete-helm-release.yml
+++ b/src/commands/delete-helm-release.yml
@@ -62,9 +62,14 @@ parameters:
       Specify the namespace of Tiller
     type: string
     default: ""
+  helm-version:
+    type: string
+    default: "v2.16.1"
+    description: the helm client version to install. e.g. v2.4.0
 
 steps:
-  - install-helm-client
+  - install-helm-client:
+      version: << parameters.helm-version >>
   - run:
       name: Delete helm release
       command: |

--- a/src/commands/delete-helm-release.yml
+++ b/src/commands/delete-helm-release.yml
@@ -10,8 +10,15 @@ parameters:
     type: string
   purge:
     description: |
+      Effective for helm 2 commands only (purging is the default in helm 3)
       Whether to remove the release from the store and make its name free for
       later use
+    type: boolean
+    default: false
+  keep-history:
+    description: |
+      Effective for helm 3 commands only.
+      Retains release history.
     type: boolean
     default: false
   timeout:
@@ -66,6 +73,12 @@ parameters:
     type: string
     default: "v2.16.1"
     description: the helm client version to install. e.g. v2.4.0
+  no-output-timeout:
+    description: |
+      Elapsed time that the helm command can run on CircleCI without output.
+      The string is a decimal with unit suffix, such as “20m”, “1.25h”, “5s”
+    type: string
+    default: "30m"
 
 steps:
   - install-helm-client:
@@ -75,6 +88,7 @@ steps:
       command: |
         RELEASE_NAME="<< parameters.release-name >>"
         PURGE="<< parameters.purge >>"
+        KEEP_HISTORY="<< parameters.keep-history >>"
         TIMEOUT="<< parameters.timeout >>"
         NAMESPACE="<< parameters.namespace >>"
         TLS="<< parameters.tls >>"
@@ -84,9 +98,7 @@ steps:
         TLS_KEY="<< parameters.tls-key >>"
         TLS_VERIFY="<< parameters.tls-verify >>"
         TILLER_NAMESPACE="<< parameters.tiller-namespace >>"
-        if [ "${PURGE}" == "true" ]; then
-          set -- "$@" --purge
-        fi
+
         if [ "${TIMEOUT}" != "-1" ]; then
           set -- "$@" --timeout="${TIMEOUT}"
         fi
@@ -114,4 +126,16 @@ steps:
         if [ -n "${TILLER_NAMESPACE}" ]; then
           set -- "$@" --tiller-namespace "${TILLER_NAMESPACE}"
         fi
+
+        VERSION_2_MATCH="$(helm version --short -c | grep 'Client: v2' || true)"
+        if [ -n "${VERSION_2_MATCH}" ]; then
+          if [ "${PURGE}" == "true" ]; then
+            set -- "$@" --purge
+          fi
+        else
+          if [ "${KEEP_HISTORY}" == "true" ]; then
+            set -- "$@" --keep-history
+          fi
+        fi
         helm delete "$@" << parameters.release-name >>
+      no_output_timeout: << parameters.no-output-timeout >>

--- a/src/commands/install-helm-chart.yml
+++ b/src/commands/install-helm-chart.yml
@@ -68,13 +68,21 @@ parameters:
       Whether to wait for the installation to be complete
     type: boolean
     default: true
+  update-repositories:
+    description: |
+      Choose to update repositories by running helm repo update.
+    type: boolean
+    default: true
 
 steps:
   - install-helm-client
-  - run:
-      name: Update repository
-      command: |
-        helm repo update
+  - when:
+    condition: << parameters.update-repositories >>
+    steps:
+      - run:
+          name: Update repositories
+          command: |
+            helm repo update
   - run:
       name: Install chart
       command: |

--- a/src/commands/install-helm-chart.yml
+++ b/src/commands/install-helm-chart.yml
@@ -133,7 +133,7 @@ steps:
           set -- "$@" --wait
         fi
 
-        VERSION_2_MATCH="$(helm version --short -c | grep 'Client: v2')"
+        VERSION_2_MATCH="$(helm version --short -c | grep 'Client: v2' || true)"
         if [ -n "${VERSION_2_MATCH}" ]; then
           if [ -n "${RELEASE_NAME}" ]; then
             set -- "$@" --name "${RELEASE_NAME}"

--- a/src/commands/install-helm-chart.yml
+++ b/src/commands/install-helm-chart.yml
@@ -73,16 +73,21 @@ parameters:
       Choose to update repositories by running helm repo update.
     type: boolean
     default: true
+  helm-version:
+    type: string
+    default: "v2.16.1"
+    description: the helm client version to install. e.g. v2.4.0
 
 steps:
-  - install-helm-client
+  - install-helm-client:
+      version: << parameters.helm-version >>
   - when:
-    condition: << parameters.update-repositories >>
-    steps:
-      - run:
-          name: Update repositories
-          command: |
-            helm repo update
+      condition: << parameters.update-repositories >>
+      steps:
+        - run:
+            name: Update repositories
+            command: |
+              helm repo update
   - run:
       name: Install chart
       command: |

--- a/src/commands/install-helm-chart.yml
+++ b/src/commands/install-helm-chart.yml
@@ -102,9 +102,6 @@ steps:
         TLS_VERIFY="<< parameters.tls-verify >>"
         TILLER_NAMESPACE="<< parameters.tiller-namespace >>"
         WAIT="<< parameters.wait >>"
-        if [ -n "${RELEASE_NAME}" ]; then
-          set -- "$@" --name "${RELEASE_NAME}"
-        fi
         if [ -n "${VALUES_TO_OVERRIDE}" ]; then
           set -- "$@" --set "${VALUES_TO_OVERRIDE}"
         fi
@@ -135,4 +132,13 @@ steps:
         if [ "${WAIT}" == "true" ]; then
           set -- "$@" --wait
         fi
-        helm install << parameters.chart >> "$@"
+
+        VERSION_2_MATCH="$(helm version --short -c | grep 'Client: v2')"
+        if [ -n "${VERSION_2_MATCH}" ]; then
+          if [ -n "${RELEASE_NAME}" ]; then
+            set -- "$@" --name "${RELEASE_NAME}"
+          fi
+          helm install << parameters.chart >> "$@"
+        else
+          helm install "${RELEASE_NAME}" << parameters.chart >> "$@"
+        fi

--- a/src/commands/install-helm-chart.yml
+++ b/src/commands/install-helm-chart.yml
@@ -75,7 +75,7 @@ parameters:
     default: true
   helm-version:
     type: string
-    default: "v2.16.1"
+    default: "v2.16.9"
     description: the helm client version to install. e.g. v2.4.0
   no-output-timeout:
     description: |

--- a/src/commands/install-helm-chart.yml
+++ b/src/commands/install-helm-chart.yml
@@ -77,6 +77,12 @@ parameters:
     type: string
     default: "v2.16.1"
     description: the helm client version to install. e.g. v2.4.0
+  no-output-timeout:
+    description: |
+      Elapsed time that the helm command can run on CircleCI without output.
+      The string is a decimal with unit suffix, such as “20m”, “1.25h”, “5s”
+    type: string
+    default: "30m"
 
 steps:
   - install-helm-client:
@@ -140,5 +146,11 @@ steps:
           fi
           helm install << parameters.chart >> "$@"
         else
-          helm install "${RELEASE_NAME}" << parameters.chart >> "$@"
+          if [ -n "${RELEASE_NAME}" ]; then
+            helm install "${RELEASE_NAME}" << parameters.chart >> "$@"
+          else
+            set -- "$@" --generate-name
+            helm install << parameters.chart >> "$@"
+          fi
         fi
+      no_output_timeout: << parameters.no-output-timeout >>

--- a/src/commands/install-helm-client.yml
+++ b/src/commands/install-helm-client.yml
@@ -33,4 +33,6 @@ steps:
         ./get_helm.sh "$@"
         if [ "${IS_VERSION_2}" == "true" ]; then
           helm init --client-only
+        else
+          helm repo add stable https://kubernetes-charts.storage.googleapis.com
         fi

--- a/src/commands/install-helm-client.yml
+++ b/src/commands/install-helm-client.yml
@@ -8,7 +8,7 @@ description: |
 parameters:
   version:
     type: string
-    default: "v2.16.1"
+    default: "v2.16.9"
     description: the helm client version to install. e.g. v2.4.0
 
 steps:

--- a/src/commands/upgrade-helm-chart.yml
+++ b/src/commands/upgrade-helm-chart.yml
@@ -126,7 +126,7 @@ parameters:
     default: true
   helm-version:
     type: string
-    default: "v2.16.1"
+    default: "v2.16.9"
     description: the helm client version to install. e.g. v2.4.0
   no-output-timeout:
     description: |

--- a/src/commands/upgrade-helm-chart.yml
+++ b/src/commands/upgrade-helm-chart.yml
@@ -124,15 +124,20 @@ parameters:
       Choose to update repositories by running helm repo update.
     type: boolean
     default: true
+  helm-version:
+    type: string
+    default: "v2.16.1"
+    description: the helm client version to install. e.g. v2.4.0
 steps:
-  - install-helm-client
+  - install-helm-client:
+      version: << parameters.helm-version >>
   - when:
-    condition: << parameters.update-repositories >>
-    steps:
-      - run:
-          name: Update repositories
-          command: |
-            helm repo update
+      condition: << parameters.update-repositories >>
+      steps:
+        - run:
+            name: Update repositories
+            command: |
+              helm repo update
   - run:
       name: Upgrade or install chart
       command: |

--- a/src/commands/upgrade-helm-chart.yml
+++ b/src/commands/upgrade-helm-chart.yml
@@ -128,6 +128,12 @@ parameters:
     type: string
     default: "v2.16.1"
     description: the helm client version to install. e.g. v2.4.0
+  no-output-timeout:
+    description: |
+      Elapsed time that the helm command can run on CircleCI without output.
+      The string is a decimal with unit suffix, such as “20m”, “1.25h”, “5s”
+    type: string
+    default: "30m"
 steps:
   - install-helm-client:
       version: << parameters.helm-version >>
@@ -215,3 +221,4 @@ steps:
           set -- "$@" --set "${VALUES_TO_OVERRIDE}"
         fi
         helm upgrade --install << parameters.release-name >> << parameters.chart >> "$@"
+      no_output_timeout: << parameters.no-output-timeout >>

--- a/src/commands/upgrade-helm-chart.yml
+++ b/src/commands/upgrade-helm-chart.yml
@@ -119,12 +119,20 @@ parameters:
       command. Format: key1=val1,key2=val2
     type: string
     default: ""
+  update-repositories:
+    description: |
+      Choose to update repositories by running helm repo update.
+    type: boolean
+    default: true
 steps:
   - install-helm-client
-  - run:
-      name: Update repository
-      command: |
-        helm repo update
+  - when:
+    condition: << parameters.update-repositories >>
+    steps:
+      - run:
+          name: Update repositories
+          command: |
+            helm repo update
   - run:
       name: Upgrade or install chart
       command: |

--- a/src/examples/install-helm-chart-with-helm2.yml
+++ b/src/examples/install-helm-chart-with-helm2.yml
@@ -1,0 +1,72 @@
+description: |
+  Demonstrate installing a helm chart on a Kubernetes cluster, with
+  helm 2.
+
+usage:
+  version: 2.1
+
+  orbs:
+    aws-eks: circleci/aws-eks@0.2
+    helm: circleci/helm@0.3
+
+  jobs:
+    install-helm-on-cluster:
+      executor: aws-eks/python
+      parameters:
+        cluster-name:
+          type: string
+          description: Cluster name
+      steps:
+        - aws-eks/update-kubeconfig-with-authenticator:
+            cluster-name: << parameters.cluster-name >>
+            install-kubectl: true
+        - helm/install-helm-on-cluster:
+            enable-cluster-wide-admin-access: true
+    install-helm-chart:
+      executor: aws-eks/python
+      parameters:
+        cluster-name:
+          type: string
+          description: Cluster name
+      steps:
+        - aws-eks/update-kubeconfig-with-authenticator:
+            cluster-name: << parameters.cluster-name >>
+        - helm/install-helm-chart:
+            chart: stable/grafana
+            release-name: grafana-release
+    delete-helm-release:
+      executor: aws-eks/python
+      parameters:
+        cluster-name:
+          type: string
+          description: Cluster name
+      steps:
+        - aws-eks/update-kubeconfig-with-authenticator:
+            cluster-name: << parameters.cluster-name >>
+        - helm/delete-helm-release:
+            release-name: grafana-release
+            purge: true
+            timeout: 600
+
+  workflows:
+    deployment:
+      jobs:
+        - aws-eks/create-cluster:
+            cluster-name: test-cluster
+        - install-helm-on-cluster:
+            cluster-name: test-cluster
+            requires:
+              - aws-eks/create-cluster
+        - install-helm-chart:
+            cluster-name: test-cluster
+            requires:
+              - install-helm-on-cluster
+        - delete-helm-release:
+            cluster-name: test-cluster
+            requires:
+              - install-helm-chart
+        - aws-eks/delete-cluster:
+            cluster-name: test-cluster
+            wait: true
+            requires:
+              - delete-helm-release

--- a/src/examples/install-helm-chart-with-helm2.yml
+++ b/src/examples/install-helm-chart-with-helm2.yml
@@ -7,7 +7,7 @@ usage:
 
   orbs:
     aws-eks: circleci/aws-eks@0.2
-    helm: circleci/helm@0.3
+    helm: circleci/helm@1.0
 
   jobs:
     install-helm-on-cluster:

--- a/src/examples/install-helm-chart-with-helm3.yml
+++ b/src/examples/install-helm-chart-with-helm3.yml
@@ -20,6 +20,7 @@ usage:
         - aws-eks/update-kubeconfig-with-authenticator:
             cluster-name: << parameters.cluster-name >>
         - helm/install-helm-chart:
+            helm-version: v3.0.0
             chart: stable/grafana
             release-name: grafana-release
     delete-helm-release:
@@ -32,6 +33,7 @@ usage:
         - aws-eks/update-kubeconfig-with-authenticator:
             cluster-name: << parameters.cluster-name >>
         - helm/delete-helm-release:
+            helm-version: v3.0.0
             release-name: grafana-release
             timeout: 600s
 

--- a/src/examples/install-helm-chart-with-helm3.yml
+++ b/src/examples/install-helm-chart-with-helm3.yml
@@ -7,7 +7,7 @@ usage:
 
   orbs:
     aws-eks: circleci/aws-eks@0.2
-    helm: circleci/helm@0.3
+    helm: circleci/helm@1.0
 
   jobs:
     install-helm-chart:

--- a/src/examples/install-helm-chart-with-helm3.yml
+++ b/src/examples/install-helm-chart-with-helm3.yml
@@ -20,7 +20,7 @@ usage:
         - aws-eks/update-kubeconfig-with-authenticator:
             cluster-name: << parameters.cluster-name >>
         - helm/install-helm-chart:
-            helm-version: v3.0.0
+            helm-version: v3.2.4
             chart: stable/grafana
             release-name: grafana-release
     delete-helm-release:
@@ -33,7 +33,7 @@ usage:
         - aws-eks/update-kubeconfig-with-authenticator:
             cluster-name: << parameters.cluster-name >>
         - helm/delete-helm-release:
-            helm-version: v3.0.0
+            helm-version: v3.2.4
             release-name: grafana-release
             timeout: 600s
 

--- a/src/examples/install-helm-chart-with-helm3.yml
+++ b/src/examples/install-helm-chart-with-helm3.yml
@@ -1,27 +1,15 @@
 description: |
   Demonstrate installing a helm chart on a Kubernetes cluster, with
-  helm 2.
+  helm 3.
 
 usage:
   version: 2.1
 
   orbs:
-    aws-eks: circleci/aws-eks@0.2.1
-    helm: circleci/helm@0.1.1
+    aws-eks: circleci/aws-eks@0.2
+    helm: circleci/helm@0.3
 
   jobs:
-    install-helm-on-cluster:
-      executor: aws-eks/python
-      parameters:
-        cluster-name:
-          type: string
-          description: Cluster name
-      steps:
-        - aws-eks/update-kubeconfig-with-authenticator:
-            cluster-name: << parameters.cluster-name >>
-            install-kubectl: true
-        - helm/install-helm-on-cluster:
-            enable-cluster-wide-admin-access: true
     install-helm-chart:
       executor: aws-eks/python
       parameters:
@@ -45,22 +33,17 @@ usage:
             cluster-name: << parameters.cluster-name >>
         - helm/delete-helm-release:
             release-name: grafana-release
-            purge: true
-            timeout: 600
+            timeout: 600s
 
   workflows:
     deployment:
       jobs:
         - aws-eks/create-cluster:
             cluster-name: test-cluster
-        - install-helm-on-cluster:
-            cluster-name: test-cluster
-            requires:
-              - aws-eks/create-cluster
         - install-helm-chart:
             cluster-name: test-cluster
             requires:
-              - install-helm-on-cluster
+              - aws-eks/create-cluster
         - delete-helm-release:
             cluster-name: test-cluster
             requires:

--- a/src/examples/install-helm-chart.yml
+++ b/src/examples/install-helm-chart.yml
@@ -1,5 +1,6 @@
 description: |
-  Demonstrate installing a helm chart on a Kubernetes cluster.
+  Demonstrate installing a helm chart on a Kubernetes cluster, with
+  helm 2.
 
 usage:
   version: 2.1


### PR DESCRIPTION
Some of the existing orb commands do not work well when used with helm 3.
This PR originally started from https://github.com/CircleCI-Public/helm-orb/pull/23 but now includes more updates to the commands.

Changes to the orb:
- `delete-helm-release`:
  - **Breaking change**: The  type of the`timeout` parameter is now `string` instead of `integer`, to resolve compatibility issues with helm 3 which requires the unit of duration to be specified (e.g. `300s` instead of `300`)
  - Ignore `purge` parameter when helm 3 is used because helm 3 doesn't support `--purge`. Resolves https://github.com/CircleCI-Public/helm-orb/issues/25
  - Add new `keep-history` parameter for use with helm 3
  - Add `helm-version` parameter to allow specification of version to be installed
  - Add `no-output-timeout` parameter. Resolves https://github.com/CircleCI-Public/helm-orb/issues/19
- `install-helm-chart`:
  - Fix `helm install` command so that it works properly with helm 3. Resolves https://github.com/CircleCI-Public/helm-orb/issues/24
  - Add `update-repositories` parameter so that running of `helm repo update` can be made optional
  - Add `helm-version` parameter to allow specification of version to be installed
  - Add `no-output-timeout` parameter. Resolves https://github.com/CircleCI-Public/helm-orb/issues/19
- `upgrade-helm-chart`:
  - Add `update-repositories` parameter so that running of `helm repo update` can be made optional
  - Add `helm-version` parameter to allow specification of version to be installed
  - Add `no-output-timeout` parameter. Resolves https://github.com/CircleCI-Public/helm-orb/issues/19
- `install-helm-client`:
  - Runs `helm repo add stable` if helm 3 is installed
  - Updated the default version of helm to a newer release of helm 2.
- Update examples so that there are separate examples for helm 2 and helm 3

This PR also adds integration tests that use helm 3.

This orb is still using a custom tag-based publishing pipeline instead of the orb starter kit-style pipeline. I plan to publish the changes as a `1.0.0` release.