### PR TITLE
fix: new location for helm stable charts

### DIFF
--- a/src/commands/install-helm-client.yml
+++ b/src/commands/install-helm-client.yml
@@ -34,5 +34,5 @@ steps:
         if [ "${IS_VERSION_2}" == "true" ]; then
           helm init --client-only
         else
-          helm repo add stable https://kubernetes-charts.storage.googleapis.com
+          helm repo add stable https://charts.helm.sh/stable
         fi


### PR DESCRIPTION
### Checklist
- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues
Helm recently announced the `stable` and `incubator` charts [moving to a new location](https://helm.sh/blog/new-location-stable-incubator-charts/). Versions 3.4.0 and 2.17.0 were updated to support this change, but the former will fail in CI due to the addition of the archived location (https://github.com/helm/helm/pull/8903):
<img width="1120" alt="Screen Shot 2020-11-08 at 18 46 46" src="https://user-images.githubusercontent.com/679761/98471108-cc667100-21f2-11eb-9ab2-0d794dcd95b4.png">

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description
Fixes the location of the `stable` chart for helm3, making sure the latest v3.4.0 doesn't fail.
