### PR TITLE
Add helm3 client download url

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
     parameters:
       release-name:
         type: string
-        default: "grafana-release"
+        default: "prometheus-release"
       cluster-name:
         type: string
         description: Cluster name
@@ -65,9 +65,13 @@ jobs:
       - aws-eks/update-kubeconfig-with-authenticator:
           cluster-name: << parameters.cluster-name >>
           install-kubectl: true
+      - run:
+          name: Install cncf stable repo
+          command: |
+            helm repo add stable http://cncf.gitlab.io/stable
       - helm/install-helm-chart:
-          chart: stable/grafana
-          release-name: grafana-release
+          chart: stable/prometheus
+          release-name: prometheus-release
           helm-version: << parameters.helm-version >>
           update-repositories: << parameters.update-repositories >>
   upgrade-helm-chart-on-eks-cluster:
@@ -89,9 +93,13 @@ jobs:
       - aws-eks/update-kubeconfig-with-authenticator:
           cluster-name: << parameters.cluster-name >>
           install-kubectl: true
+      - run:
+          name: Install cncf stable repo
+          command: |
+            helm repo add stable http://cncf.gitlab.io/stable
       - helm/upgrade-helm-chart:
-          chart: stable/grafana
-          release-name: grafana-release
+          chart: stable/prometheus
+          release-name: prometheus-release
           helm-version: << parameters.helm-version >>
           update-repositories: << parameters.update-repositories >>
           # test specifying no-output-timeout
@@ -113,8 +121,12 @@ jobs:
       - aws-eks/update-kubeconfig-with-authenticator:
           cluster-name: << parameters.cluster-name >>
           install-kubectl: true
+      - run:
+          name: Install cncf stable repo
+          command: |
+            helm repo add stable http://cncf.gitlab.io/stable
       - helm/delete-helm-release:
-          release-name: grafana-release
+          release-name: prometheus-release
           purge: true
           timeout: << parameters.timeout >>
           helm-version: << parameters.helm-version >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,8 @@ jobs:
       - aws-eks/update-kubeconfig-with-authenticator:
           cluster-name: << parameters.cluster-name >>
           install-kubectl: true
+      - helm/install-helm-client:
+          version: << parameters.helm-version >>
       - run:
           name: Install cncf stable repo
           command: |
@@ -93,6 +95,8 @@ jobs:
       - aws-eks/update-kubeconfig-with-authenticator:
           cluster-name: << parameters.cluster-name >>
           install-kubectl: true
+      - helm/install-helm-client:
+          version: << parameters.helm-version >>
       - run:
           name: Install cncf stable repo
           command: |
@@ -121,6 +125,8 @@ jobs:
       - aws-eks/update-kubeconfig-with-authenticator:
           cluster-name: << parameters.cluster-name >>
           install-kubectl: true
+      - helm/install-helm-client:
+          version: << parameters.helm-version >>
       - run:
           name: Install cncf stable repo
           command: |

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
-# helm Orb [![CircleCI status](https://circleci.com/gh/CircleCI-Public/helm-orb.svg "CircleCI status")](https://circleci.com/gh/CircleCI-Public/helm-orb) [![CircleCI Orb Version](https://img.shields.io/badge/endpoint.svg?url=https://badges.circleci.io/orb/circleci/helm)](https://circleci.com/orbs/registry/orb/circleci/helm) [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/CircleCI-Public/helm-orb/blob/master/LICENSE) [![CircleCI Community](https://img.shields.io/badge/community-CircleCI%20Discuss-343434.svg)](https://discuss.circleci.com/c/ecosystem/orbs)
+# helm Orb [![CircleCI status](https://circleci.com/gh/CircleCI-Public/helm-orb.svg "CircleCI status")](https://circleci.com/gh/CircleCI-Public/helm-orb) [![CircleCI Orb Version](https://img.shields.io/badge/endpoint.svg?url=https://badges.circleci.io/orb/circleci/helm)](https://circleci.com/developer/orbs/orb/circleci/helm) [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/CircleCI-Public/helm-orb/blob/master/LICENSE) [![CircleCI Community](https://img.shields.io/badge/community-CircleCI%20Discuss-343434.svg)](https://discuss.circleci.com/c/ecosystem/orbs)
 
 A CircleCI Orb to simplify deployments to Kubernetes using Helm.
 
 Here are the features that the Helm orb provides:
 
 - Installing the helm client (`install-helm-client`)
-- Installing helm on a cluster (`install-helm-on-cluster`)
 - Installing helm charts (`install-helm-chart`) and deleting releases (`delete-helm-release`)
 
 Table of Contents
@@ -17,7 +16,7 @@ Table of Contents
 
 ## Usage
 
-See the [orb registry listing](http://circleci.com/orbs/registry/orb/circleci/helm) for usage guidelines.
+See the [orb registry listing](https://circleci.com/developer/orbs/orb/circleci/helm) for usage guidelines.
 
 ## Requirements
 
@@ -25,75 +24,7 @@ See the [orb registry listing](http://circleci.com/orbs/registry/orb/circleci/he
 
 ## Examples
 
-```
-version: 2.1
-
-orbs:
-  aws-eks: circleci/aws-eks@0.2.1
-  helm: circleci/helm@0.1.1
-
-jobs:
-  install-helm-on-cluster:
-    executor: aws-eks/python
-    parameters:
-      cluster-name:
-        type: string
-        description: Cluster name
-    steps:
-      - aws-eks/update-kubeconfig-with-authenticator:
-          cluster-name: << parameters.cluster-name >>
-          install-kubectl: true
-      - helm/install-helm-on-cluster:
-          enable-cluster-wide-admin-access: true
-  install-helm-chart:
-    executor: aws-eks/python
-    parameters:
-      cluster-name:
-        type: string
-        description: Cluster name
-    steps:
-      - aws-eks/update-kubeconfig-with-authenticator:
-          cluster-name: << parameters.cluster-name >>
-      - helm/install-helm-chart:
-          chart: stable/grafana
-          release-name: grafana-release
-  delete-helm-release:
-    executor: aws-eks/python
-    parameters:
-      cluster-name:
-        type: string
-        description: Cluster name
-    steps:
-      - aws-eks/update-kubeconfig-with-authenticator:
-          cluster-name: << parameters.cluster-name >>
-      - helm/delete-helm-release:
-          release-name: grafana-release
-          purge: true
-          timeout: 600
-
-workflows:
-  deployment:
-    jobs:
-      - aws-eks/create-cluster:
-          cluster-name: test-cluster
-      - install-helm-on-cluster:
-          cluster-name: test-cluster
-          requires:
-            - aws-eks/create-cluster
-      - install-helm-chart:
-          cluster-name: test-cluster
-          requires:
-            - install-helm-on-cluster
-      - delete-helm-release:
-          cluster-name: test-cluster
-          requires:
-            - install-helm-chart
-      - aws-eks/delete-cluster:
-          cluster-name: test-cluster
-          wait: true
-          requires:
-            - delete-helm-release
-```
+Refer to the usage examples [here](https://circleci.com/developer/orbs/orb/circleci/helm#usage-install-helm-chart-with-helm3).
 
 ## Contributing
 

--- a/src/commands/install-helm-client.yml
+++ b/src/commands/install-helm-client.yml
@@ -28,6 +28,10 @@ steps:
           fi
         fi
         INSTALL_SCRIPT="https://raw.githubusercontent.com/helm/helm/master/scripts/get"
+        if [ "${IS_VERSION_2}" == "false" ]; then
+          INSTALL_SCRIPT="https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3"
+        fi
+
         curl "${INSTALL_SCRIPT}" > get_helm.sh
         chmod 700 get_helm.sh
         ./get_helm.sh "$@"

--- a/src/examples/install-helm-chart-with-helm2.yml
+++ b/src/examples/install-helm-chart-with-helm2.yml
@@ -31,9 +31,15 @@ usage:
       steps:
         - aws-eks/update-kubeconfig-with-authenticator:
             cluster-name: << parameters.cluster-name >>
+        - helm/install-helm-client:
+            version: v2.16.9
+        - run:
+            name: Add cncf stable repo
+            command: |
+              helm repo add stable http://cncf.gitlab.io/stable
         - helm/install-helm-chart:
-            chart: stable/grafana
-            release-name: grafana-release
+            chart: stable/prometheus
+            release-name: prometheus-release
     delete-helm-release:
       executor: aws-eks/python
       parameters:
@@ -43,8 +49,14 @@ usage:
       steps:
         - aws-eks/update-kubeconfig-with-authenticator:
             cluster-name: << parameters.cluster-name >>
+        - helm/install-helm-client:
+            version: v2.16.9
+        - run:
+            name: Add cncf stable repo
+            command: |
+              helm repo add stable http://cncf.gitlab.io/stable
         - helm/delete-helm-release:
-            release-name: grafana-release
+            release-name: prometheus-release
             purge: true
             timeout: 600
 


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [ x ] All new jobs, commands, executors, parameters have descriptions
- [ x ] Examples have been added for any significant new features
- [ x ] README has been updated, if necessary

### Motivation, issues
Helm3 uses `https://github.com/helm/helm/blob/master/scripts/get-helm-3` url for getting helm v3 client. However current helm orb is using `https://github.com/helm/helm/blob/master/scripts/get` for getting both v2 and v3 client version.
<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description
I added helm3 donwload url if `${IS_VERSION_2}`is false.
<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
