### PR TITLE
Improve suggestion - add atomic option for upgrading chart

### DIFF
--- a/src/commands/upgrade-helm-chart.yml
+++ b/src/commands/upgrade-helm-chart.yml
@@ -134,6 +134,12 @@ parameters:
       The string is a decimal with unit suffix, such as “20m”, “1.25h”, “5s”
     type: string
     default: "30m"
+  atomic:
+    description: |
+      if set, upgrade process rolls back changes made in case of failed upgrade.
+      The --wait flag will be set automatically if --atomic is used
+    type: boolean
+    default: false
 steps:
   - install-helm-client:
       version: << parameters.helm-version >>
@@ -148,6 +154,7 @@ steps:
       name: Upgrade or install chart
       command: |
         TIMEOUT="<< parameters.timeout >>"
+        ATOMIC="<< parameters.atomic >>"
         WAIT="<< parameters.wait >>"
         NO_HOOKS="<< parameters.no-hooks >>"
         RECREATE_PODS="<< parameters.recreate-pods >>"
@@ -177,6 +184,9 @@ steps:
         fi
         if [ "${RECREATE_PODS}"  == "true" ]; then
           set -- "$@" --recreate-pods
+        fi
+        if [ "${ATOMIC}" == "true" ]; then
+          set -- "$@" --atomic
         fi
         if [ "${WAIT}" == "true" ]; then
           set -- "$@" --wait


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->
Wtih Helm `atomic` option, users can acheive auto rollback if there are issues on deploying pods. By this idea, `helm-orb` can provide more practical usages to circleci users who are using kubernetes.
### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
add `atomic` helm upgrade option to `upgrade-helm-chart` commands.
