### PR TITLE
fix: new stable repo url for helm2 [semver:minor]

### DIFF
--- a/src/commands/install-helm-client.yml
+++ b/src/commands/install-helm-client.yml
@@ -36,7 +36,7 @@ steps:
         chmod 700 get_helm.sh
         ./get_helm.sh "$@"
         if [ "${IS_VERSION_2}" == "true" ]; then
-          helm init --client-only
+          helm init --client-only --stable-repo-url https://charts.helm.sh/stable
         else
           helm repo add stable https://charts.helm.sh/stable
         fi

--- a/src/commands/install-helm-client.yml
+++ b/src/commands/install-helm-client.yml
@@ -10,6 +10,10 @@ parameters:
     type: string
     default: "v2.16.9"
     description: the helm client version to install. e.g. v2.4.0
+  stable-repo-url:
+    type: string
+    default: "https://charts.helm.sh/stable"
+    description: the helm stable repository url to use.
 
 steps:
   - run:
@@ -35,8 +39,9 @@ steps:
         curl "${INSTALL_SCRIPT}" > get_helm.sh
         chmod 700 get_helm.sh
         ./get_helm.sh "$@"
+        STABLE_REPO_URL="<< parameters.stable-repo-url >>"
         if [ "${IS_VERSION_2}" == "true" ]; then
-          helm init --client-only --stable-repo-url https://charts.helm.sh/stable
+          helm init --client-only --stable-repo-url "${STABLE_REPO_URL}"
         else
-          helm repo add stable https://charts.helm.sh/stable
+          helm repo add stable "${STABLE_REPO_URL}"
         fi


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues
See: https://github.com/CircleCI-Public/helm-orb/issues/34
Since the old stable repository have been moved by Google the pod is failing for Helm2.
This PR fixes it. 

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description
- Fixes the location of the stable chart for helm2, making sure the latest v2.17.0 doesn't fail.
- Use a parameter for the stable repo URL for both helm2 and helm3.
<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
