### PR TITLE
bump helm version to 3.5.3 and add wait-for-jobs arg

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,7 +195,7 @@ workflows:
             - install-helm-on-eks-cluster
       - install-helm-chart-on-eks-cluster:
           name: install-helm-chart-on-eks-cluster-helm3
-          helm-version: v3.2.4
+          helm-version: v3.5.3
           # test repo update
           update-repositories: true
           cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-helm3-eks
@@ -209,7 +209,7 @@ workflows:
             - install-helm-chart-on-eks-cluster-helm2
       - upgrade-helm-chart-on-eks-cluster:
           name: upgrade-helm-chart-on-eks-cluster-helm3
-          helm-version: v3.2.4
+          helm-version: v3.5.3
           update-repositories: false
           cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-helm3-eks
           requires:
@@ -222,14 +222,14 @@ workflows:
             - upgrade-helm-chart-on-eks-cluster-helm2
       - delete-helm-release-on-eks-cluster:
           name: delete-helm-release-on-eks-cluster-helm3
-          helm-version: v3.2.4
+          helm-version: v3.5.3
           cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-helm3-eks
           requires:
             - upgrade-helm-chart-on-eks-cluster-helm3
 
       - install-helm-chart-on-eks-cluster:
           name: reinstall-helm-chart-on-eks-cluster-helm3
-          helm-version: v3.2.4
+          helm-version: v3.5.3
           # Test auto-generated release name
           release-name: ""
           cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-helm3-eks
@@ -237,7 +237,7 @@ workflows:
             - delete-helm-release-on-eks-cluster-helm3
       - delete-helm-release-on-eks-cluster:
           name: delete-helm-release-on-eks-cluster-again-helm3
-          helm-version: v3.2.4
+          helm-version: v3.5.3
           cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-helm3-eks
           # test timeout
           timeout: "600s"

--- a/src/commands/install-helm-chart.yml
+++ b/src/commands/install-helm-chart.yml
@@ -68,6 +68,11 @@ parameters:
       Whether to wait for the installation to be complete
     type: boolean
     default: true
+  wait-for-jobs:
+    description: |
+      Whether to wait until all Jobs have been completed before marking the release as successful.
+    type: boolean
+    default: true
   update-repositories:
     description: |
       Choose to update repositories by running helm repo update.
@@ -108,6 +113,7 @@ steps:
         TLS_VERIFY="<< parameters.tls-verify >>"
         TILLER_NAMESPACE="<< parameters.tiller-namespace >>"
         WAIT="<< parameters.wait >>"
+        WAIT_FOR_JOBS="<< parameters.wait-for-jobs >>"
         if [ -n "${VALUES_TO_OVERRIDE}" ]; then
           set -- "$@" --set "${VALUES_TO_OVERRIDE}"
         fi
@@ -137,6 +143,9 @@ steps:
         fi
         if [ "${WAIT}" == "true" ]; then
           set -- "$@" --wait
+        fi
+        if [ "${WAIT_FOR_JOBS}" == "true" ]; then
+          set -- "$@" --wait-for-jobs
         fi
 
         VERSION_2_MATCH="$(helm version --short -c | grep 'Client: v2' || true)"

--- a/src/commands/upgrade-helm-chart.yml
+++ b/src/commands/upgrade-helm-chart.yml
@@ -27,6 +27,11 @@ parameters:
       Whether to wait for the installation to be complete.
     type: boolean
     default: true
+  wait-for-jobs:
+    description: |
+      Whether to wait until all Jobs have been completed before marking the release as successful.
+    type: boolean
+    default: true
   timeout:
     description: |
       If timeout is reached, the release will be marked as FAILED.
@@ -156,6 +161,7 @@ steps:
         TIMEOUT="<< parameters.timeout >>"
         ATOMIC="<< parameters.atomic >>"
         WAIT="<< parameters.wait >>"
+        WAIT_FOR_JOBS="<< parameters.wait-for-jobs >>"
         NO_HOOKS="<< parameters.no-hooks >>"
         RECREATE_PODS="<< parameters.recreate-pods >>"
         TLS="<< parameters.tls >>"
@@ -190,6 +196,9 @@ steps:
         fi
         if [ "${WAIT}" == "true" ]; then
           set -- "$@" --wait
+        fi
+        if [ "${WAIT_FOR_JOBS}" == "true" ]; then
+          set -- "$@" --wait-for-jobs
         fi
         if [ "${TLS}" == "true" ]; then
           set -- "$@" --tls

--- a/src/examples/install-helm-chart-with-helm3.yml
+++ b/src/examples/install-helm-chart-with-helm3.yml
@@ -20,7 +20,7 @@ usage:
         - aws-eks/update-kubeconfig-with-authenticator:
             cluster-name: << parameters.cluster-name >>
         - helm/install-helm-chart:
-            helm-version: v3.2.4
+            helm-version: v3.5.3
             chart: stable/grafana
             release-name: grafana-release
     delete-helm-release:
@@ -33,7 +33,7 @@ usage:
         - aws-eks/update-kubeconfig-with-authenticator:
             cluster-name: << parameters.cluster-name >>
         - helm/delete-helm-release:
-            helm-version: v3.2.4
+            helm-version: v3.5.3
             release-name: grafana-release
             timeout: 600s
 


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

The motivation of this PR is to add the new argument "wait-for-jobs" for [helm install](https://helm.sh/docs/helm/helm_install/) and [upgrade](https://helm.sh/docs/helm/helm_upgrade/) that solves the issues described on [#5948](https://github.com/helm/helm/issues/5948) and introduced on version 3.5.0 on the PR [#8363](https://github.com/helm/helm/pull/8363).
<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description

To be able to add the new flag wait-for-jobs I had to also update the helm version to the latest version.
<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
