### PR TITLE
feat: add create_namespace parameter

### DIFF
--- a/src/commands/install_helm_chart.yml
+++ b/src/commands/install_helm_chart.yml
@@ -32,6 +32,11 @@ parameters:
       The kubernetes namespace that should be used.
     type: string
     default: ""
+  create_namespace:
+    description: |
+      This parameter creates the kubernetes namespace if the one provided does not exist.
+    type: boolean
+    default: false
   wait:
     description: |
       Whether to wait for the installation or upgrade to be complete
@@ -76,6 +81,7 @@ steps:
         HELM_STR_VALUES_TO_OVERRIDE: << parameters.values_to_override >>
         HELM_STR_NAMESPACE: << parameters.namespace >>
         HELM_BOOL_WAIT: << parameters.wait >>
+        HELM_BOOL_CREATE_NAMESPACE: << parameters.create_namespace >>
         HELM_STR_CHART: << parameters.chart >>
         HELM_BOOL_WAIT_FOR_JOBS: << parameters.wait_for_jobs >>
       command: <<include(scripts/install_helm_chart.sh)>>

--- a/src/commands/upgrade_helm_chart.yml
+++ b/src/commands/upgrade_helm_chart.yml
@@ -27,6 +27,11 @@ parameters:
       The kubernetes namespace that should be used.
     type: string
     default: ""
+  create_namespace:
+    description: |
+      This parameter creates the kubernetes namespace if the one provided does not exist.
+    type: boolean
+    default: false
   wait:
     description: |
       Whether to wait for the installation to be complete.
@@ -126,6 +131,7 @@ steps:
         HELM_BOOL_NO_HOOKS: << parameters.no_hooks >>
         HELM_BOOL_RECREATE_PODS: << parameters.recreate_pods >>
         HELM_STR_NAMESPACE: << parameters.namespace >>
+        HELM_BOOL_CREATE_NAMESPACE: << parameters.create_namespace >>
         HELM_STR_DEVEL: << parameters.devel >>
         HELM_BOOL_DRY_RUN: << parameters.dry_run >>
         HELM_BOOL_RESET_VALUES: << parameters.reset_values >>

--- a/src/scripts/install_helm_chart.sh
+++ b/src/scripts/install_helm_chart.sh
@@ -12,7 +12,11 @@ if [ "${HELM_BOOL_WAIT_FOR_JOBS}" -eq "1" ]; then
   set -- "$@" --wait-for-jobs
 fi
 if [ -n "${HELM_STR_NAMESPACE}" ]; then
-  set -- "$@" --namespace="${HELM_STR_NAMESPACE}"
+  if [ "${HELM_BOOL_CREATE_NAME_SPACE}" -eq "1" ]; then
+    set -- "$@" --create-namespace --namespace="${HELM_STR_NAMESPACE}"
+  else
+    set -- "$@" --namespace="${HELM_STR_NAMESPACE}"
+  fi
 fi
 if [ "${HELM_BOOL_WAIT}" -eq "1" ]; then
   set -- "$@" --wait

--- a/src/scripts/upgrade_helm_chart.sh
+++ b/src/scripts/upgrade_helm_chart.sh
@@ -11,7 +11,11 @@ HELM_STR_ADD_REPO="$(echo "${HELM_STR_ADD_REPO}" | circleci env subst)"
 
 set -x
 if [ -n "${HELM_STR_NAMESPACE}" ]; then
-  set -- "$@" --namespace="${HELM_STR_NAMESPACE}"
+  if [ "${HELM_BOOL_CREATE_NAME_SPACE}" -eq "1" ]; then
+    set -- "$@" --create-namespace --namespace="${HELM_STR_NAMESPACE}"
+  else
+    set -- "$@" --namespace="${HELM_STR_NAMESPACE}"
+  fi
 fi
 if [ -n "${HELM_STR_TIMEOUT}" ]; then
   set -- "$@" --timeout "${HELM_STR_TIMEOUT}"


### PR DESCRIPTION
Currently in the `install_helm_chart` and the `upgrade_helm_chart` commands, if the provided kubernetes `namespace` does not exist, the commands fail. 

This `PR` adds the `create_namespace` parameter. When set to `true`, it enables users to create the namespace if it doesn't exist.