### PR TITLE
feat!: update parameters

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -58,7 +58,7 @@ jobs:
         description: the helm chart to install
       debug:
         description: |
-          Enable debug mode by adding 
+          Enable debug mode 
         type: boolean
         default: false
     steps:
@@ -102,7 +102,7 @@ jobs:
         description: the helm chart to install
       debug:
         description: |
-          Enable debug mode by adding 
+          Enable debug mode
         type: boolean
         default: false
     steps:
@@ -112,7 +112,6 @@ jobs:
           aws-region: us-west-2
       - helm/install_helm_client:
           version: << parameters.helm_version >>
-
       - run:
           name: Install cncf stable repo
           command: |

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -94,6 +94,12 @@ jobs:
         type: string
         default: "prometheus-community/prometheus"
         description: the helm chart to install
+      history_max:  
+        description: |
+          Helm stores historical revisions for a given release. Specify the amount of historical
+          releases stored. By default, 10 releases are stored.
+        type: string
+        default: ""
     steps:
       - aws-eks/update-kubeconfig-with-authenticator:
           cluster-name: << parameters.cluster-name >>
@@ -101,6 +107,7 @@ jobs:
           aws-region: us-west-2
       - helm/install_helm_client:
           version: << parameters.helm_version >>
+          history_max: << parameters.history_max >>
       - run:
           name: Install cncf stable repo
           command: |
@@ -109,7 +116,9 @@ jobs:
           add_repo: << parameters.add_repo >>
           chart: << parameters.chart >>
           release_name: << parameters.release_name >>
-          helm_version: << parameters.helm_version >>          # test specifying no_output_timeout
+          helm_version: << parameters.helm_version >>
+          history_max: << parameters.history_max >>
+          # test specifying no_output_timeout
           no_output_timeout: 25m
   delete-helm-release-on-eks-cluster:
     docker:
@@ -163,6 +172,7 @@ workflows:
           cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-helm4-eks
           add_repo: https://prometheus-community.github.io/helm-charts
           chart: prometheus-community/prometheus
+          history_max: "25"
           context: CPE_ORBS_AWS
           filters: *filters
           requires:
@@ -171,6 +181,7 @@ workflows:
           name: upgrade-helm-chart-on-eks-cluster-helm4
           helm_version: v3.8.2
           cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-helm4-eks
+          history_max: "25"
           context: CPE_ORBS_AWS
           filters: *filters
           requires:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -23,15 +23,6 @@ jobs:
     steps:
       - helm/install_helm_client:
           version: << parameters.version >>
-  helm-plugin-install-test:
-    docker:
-      - image: cimg/base:current
-    parameters:
-      helm_plugin_url:
-        type: string
-    steps:
-      - helm/install_helm_plugin:
-          helm_plugin_url: << parameters.helm_plugin_url >>
   install-helm-on-eks-cluster:
     docker:
       - image: cimg/python:3.10
@@ -159,10 +150,6 @@ workflows:
       - helm-client-install-test:
           name: helm-client-install-specific-version
           version: v3.0.0
-          filters: *filters
-      - helm-plugin-install-test:
-          name: helm-plugin-install-env
-          helm_plugin_url: https://github.com/adamreese/helm-env
           filters: *filters
       - aws-eks/create-cluster:
           name: create-cluster-helm4

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -23,6 +23,15 @@ jobs:
     steps:
       - helm/install_helm_client:
           version: << parameters.version >>
+  helm-plugin-install-test:
+    docker:
+      - image: cimg/base:current
+    parameters:
+      helm_plugin_url:
+        type: string
+    steps:
+      - helm/install_helm_plugin:
+          helm_plugin_url: << parameters.helm_plugin_url >>
   install-helm-on-eks-cluster:
     docker:
       - image: cimg/python:3.10
@@ -50,17 +59,12 @@ jobs:
         description: the helm client version to install. e.g. v3.0.0
       add_repo:
         type: string
-        default: "https://prometheus-community.github.io/helm-charts"
+        default: ""
         description: the helm chart repository url to use
       chart:
         type: string
         default: "prometheus-community/prometheus"
         description: the helm chart to install
-      update_repositories:
-        description: |
-          Choose to update repositories by running helm repo update.
-        type: boolean
-        default: true
     steps:
       - aws-eks/update-kubeconfig-with-authenticator:
           cluster-name: << parameters.cluster-name >>
@@ -77,7 +81,6 @@ jobs:
           add_repo: << parameters.add_repo >>
           release_name: << parameters.release_name >>
           helm_version: << parameters.helm_version >>
-          update_repositories: << parameters.update_repositories >>
   upgrade-helm-chart-on-eks-cluster:
     docker:
       - image: cimg/python:3.10
@@ -100,11 +103,6 @@ jobs:
         type: string
         default: "prometheus-community/prometheus"
         description: the helm chart to install
-      update_repositories:
-        description: |
-          Choose to update repositories by running helm repo update.
-        type: boolean
-        default: true
     steps:
       - aws-eks/update-kubeconfig-with-authenticator:
           cluster-name: << parameters.cluster-name >>
@@ -120,9 +118,7 @@ jobs:
           add_repo: << parameters.add_repo >>
           chart: << parameters.chart >>
           release_name: << parameters.release_name >>
-          helm_version: << parameters.helm_version >>
-          update_repositories: << parameters.update_repositories >>
-          # test specifying no_output_timeout
+          helm_version: << parameters.helm_version >>          # test specifying no_output_timeout
           no_output_timeout: 25m
   delete-helm-release-on-eks-cluster:
     docker:
@@ -164,6 +160,10 @@ workflows:
           name: helm-client-install-specific-version
           version: v3.0.0
           filters: *filters
+      - helm-plugin-install-test:
+          name: helm-plugin-install-env
+          helm_plugin_url: https://github.com/adamreese/helm-env
+          filters: *filters
       - aws-eks/create-cluster:
           name: create-cluster-helm4
           cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-helm4-eks
@@ -173,7 +173,6 @@ workflows:
           name: install-helm-chart-on-eks-cluster-helm4
           helm_version: v3.8.2
           # test repo update
-          update_repositories: true
           cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-helm4-eks
           add_repo: https://prometheus-community.github.io/helm-charts
           chart: prometheus-community/prometheus
@@ -184,7 +183,6 @@ workflows:
       - upgrade-helm-chart-on-eks-cluster:
           name: upgrade-helm-chart-on-eks-cluster-helm4
           helm_version: v3.8.2
-          update_repositories: false
           cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-helm4-eks
           context: CPE_ORBS_AWS
           filters: *filters

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -56,6 +56,11 @@ jobs:
         type: string
         default: "prometheus-community/prometheus"
         description: the helm chart to install
+      debug:
+        description: |
+          Enable debug mode by adding 
+        type: boolean
+        default: false
     steps:
       - aws-eks/update-kubeconfig-with-authenticator:
           cluster-name: << parameters.cluster-name >>
@@ -72,6 +77,7 @@ jobs:
           add_repo: << parameters.add_repo >>
           release_name: << parameters.release_name >>
           helm_version: << parameters.helm_version >>
+          debug: << parameters.debug >>
   upgrade-helm-chart-on-eks-cluster:
     docker:
       - image: cimg/python:3.10
@@ -94,12 +100,11 @@ jobs:
         type: string
         default: "prometheus-community/prometheus"
         description: the helm chart to install
-      history_max:  
+      debug:
         description: |
-          Helm stores historical revisions for a given release. Specify the amount of historical
-          releases stored. By default, 10 releases are stored.
-        type: string
-        default: ""
+          Enable debug mode by adding 
+        type: boolean
+        default: false
     steps:
       - aws-eks/update-kubeconfig-with-authenticator:
           cluster-name: << parameters.cluster-name >>
@@ -107,7 +112,7 @@ jobs:
           aws-region: us-west-2
       - helm/install_helm_client:
           version: << parameters.helm_version >>
-          history_max: << parameters.history_max >>
+
       - run:
           name: Install cncf stable repo
           command: |
@@ -117,7 +122,7 @@ jobs:
           chart: << parameters.chart >>
           release_name: << parameters.release_name >>
           helm_version: << parameters.helm_version >>
-          history_max: << parameters.history_max >>
+          debug: << parameters.debug >>
           # test specifying no_output_timeout
           no_output_timeout: 25m
   delete-helm-release-on-eks-cluster:
@@ -172,7 +177,7 @@ workflows:
           cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-helm4-eks
           add_repo: https://prometheus-community.github.io/helm-charts
           chart: prometheus-community/prometheus
-          history_max: "25"
+          debug: true
           context: CPE_ORBS_AWS
           filters: *filters
           requires:
@@ -181,7 +186,7 @@ workflows:
           name: upgrade-helm-chart-on-eks-cluster-helm4
           helm_version: v3.8.2
           cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-helm4-eks
-          history_max: "25"
+          debug: true
           context: CPE_ORBS_AWS
           filters: *filters
           requires:

--- a/src/commands/install_helm_chart.yml
+++ b/src/commands/install_helm_chart.yml
@@ -62,7 +62,12 @@ parameters:
       The string is a decimal with unit suffix, such as “20m”, “1.25h”, “5s”
     type: string
     default: "30m"
-
+  history_max:  
+    description: |
+      Helm stores historical revisions for a given release. Specify the amount of historical
+      releases stored. By default, 10 releases are stored.
+    type: string
+    default: ""
 steps:
   - install_helm_client:
       version: << parameters.helm_version >>
@@ -84,5 +89,6 @@ steps:
         HELM_BOOL_CREATE_NAMESPACE: << parameters.create_namespace >>
         HELM_STR_CHART: << parameters.chart >>
         HELM_BOOL_WAIT_FOR_JOBS: << parameters.wait_for_jobs >>
+        HELM_STR_HISTORY_MAX: << parameters.history_max >>
       command: <<include(scripts/install_helm_chart.sh)>>
       no_output_timeout: << parameters.no_output_timeout >>

--- a/src/commands/install_helm_chart.yml
+++ b/src/commands/install_helm_chart.yml
@@ -68,6 +68,11 @@ parameters:
       releases stored. By default, 10 releases are stored.
     type: string
     default: ""
+  debug:
+    description: |
+      Enable debug mode by adding --debug to helm command. Defaults to false.
+    type: boolean
+    default: false
 steps:
   - install_helm_client:
       version: << parameters.helm_version >>
@@ -89,6 +94,7 @@ steps:
         HELM_BOOL_CREATE_NAMESPACE: << parameters.create_namespace >>
         HELM_STR_CHART: << parameters.chart >>
         HELM_BOOL_WAIT_FOR_JOBS: << parameters.wait_for_jobs >>
+        HELM_BOOL_DEBUG: << parameters.debug >>
         HELM_STR_HISTORY_MAX: << parameters.history_max >>
       command: <<include(scripts/install_helm_chart.sh)>>
       no_output_timeout: << parameters.no_output_timeout >>

--- a/src/commands/install_helm_chart.yml
+++ b/src/commands/install_helm_chart.yml
@@ -62,12 +62,6 @@ parameters:
       The string is a decimal with unit suffix, such as “20m”, “1.25h”, “5s”
     type: string
     default: "30m"
-  history_max:  
-    description: |
-      Helm stores historical revisions for a given release. Specify the amount of historical
-      releases stored. By default, 10 releases are stored.
-    type: string
-    default: ""
   debug:
     description: |
       Enable debug mode by adding --debug to helm command. Defaults to false.
@@ -95,6 +89,5 @@ steps:
         HELM_STR_CHART: << parameters.chart >>
         HELM_BOOL_WAIT_FOR_JOBS: << parameters.wait_for_jobs >>
         HELM_BOOL_DEBUG: << parameters.debug >>
-        HELM_STR_HISTORY_MAX: << parameters.history_max >>
       command: <<include(scripts/install_helm_chart.sh)>>
       no_output_timeout: << parameters.no_output_timeout >>

--- a/src/commands/install_helm_client.yml
+++ b/src/commands/install_helm_client.yml
@@ -8,15 +8,10 @@ parameters:
     type: string
     default: "v3.8.2"
     description: the helm client version to install. e.g. v3.8.0
-  stable_repo_url:
-    type: string
-    default: "https://charts.helm.sh/stable"
-    description: the helm stable repository url to use.
 
 steps:
   - run:
       name: Install and init the helm client (if necessary)
       environment:
         HELM_STR_VERSION: << parameters.version >>
-        HELM_STR_STABLE_REPO_URL: << parameters.stable_repo_url >>
       command: <<include(scripts/install_helm_client.sh)>>

--- a/src/commands/upgrade_helm_chart.yml
+++ b/src/commands/upgrade_helm_chart.yml
@@ -115,6 +115,12 @@ parameters:
       The --wait flag will be set automatically if --atomic is used
     type: boolean
     default: false
+  history_max:  
+    description: |
+      Helm stores historical revisions for a given release. Specify the amount of historical
+      releases stored. By default, 10 releases are stored.
+    type: string
+    default: ""
 steps:
   - install_helm_client:
       version: << parameters.helm_version >>
@@ -140,5 +146,6 @@ steps:
         HELM_STR_ADD_REPO: << parameters.add_repo >>
         HELM_BOOL_WAIT_FOR_JOBS: << parameters.wait_for_jobs >>
         HELM_BOOL_FORCE: << parameters.force >>
+        HELM_STR_HISTORY_MAX: << parameters.history_max >>
       command: <<include(scripts/upgrade_helm_chart.sh)>>
       no_output_timeout: << parameters.no_output_timeout >>

--- a/src/commands/upgrade_helm_chart.yml
+++ b/src/commands/upgrade_helm_chart.yml
@@ -17,6 +17,7 @@ parameters:
       The url for the helm chart repository used as part of helm repo add
       command
     type: string
+    default: ""
   release_name:
     description: |
       Specify a name for the release.

--- a/src/commands/upgrade_helm_chart.yml
+++ b/src/commands/upgrade_helm_chart.yml
@@ -115,12 +115,6 @@ parameters:
       The --wait flag will be set automatically if --atomic is used
     type: boolean
     default: false
-  history_max:  
-    description: |
-      Helm stores historical revisions for a given release. Specify the amount of historical
-      releases stored. By default, 10 releases are stored.
-    type: string
-    default: ""
   debug:
     description: |
       Enable debug mode by adding --debug to helm command. Defaults to false.
@@ -151,7 +145,6 @@ steps:
         HELM_STR_ADD_REPO: << parameters.add_repo >>
         HELM_BOOL_WAIT_FOR_JOBS: << parameters.wait_for_jobs >>
         HELM_BOOL_FORCE: << parameters.force >>
-        HELM_STR_HISTORY_MAX: << parameters.history_max >>
         HELM_BOOL_DEBUG: << parameters.debug >>
       command: <<include(scripts/upgrade_helm_chart.sh)>>
       no_output_timeout: << parameters.no_output_timeout >>

--- a/src/commands/upgrade_helm_chart.yml
+++ b/src/commands/upgrade_helm_chart.yml
@@ -98,11 +98,6 @@ parameters:
       command. Format: key1=val1,key2=val2
     type: string
     default: ""
-  update_repositories:
-    description: |
-      Choose to update repositories by running helm repo update.
-    type: boolean
-    default: true
   helm_version:
     type: string
     default: "v3.8.2"

--- a/src/commands/upgrade_helm_chart.yml
+++ b/src/commands/upgrade_helm_chart.yml
@@ -121,6 +121,11 @@ parameters:
       releases stored. By default, 10 releases are stored.
     type: string
     default: ""
+  debug:
+    description: |
+      Enable debug mode by adding --debug to helm command. Defaults to false.
+    type: boolean
+    default: false
 steps:
   - install_helm_client:
       version: << parameters.helm_version >>
@@ -147,5 +152,6 @@ steps:
         HELM_BOOL_WAIT_FOR_JOBS: << parameters.wait_for_jobs >>
         HELM_BOOL_FORCE: << parameters.force >>
         HELM_STR_HISTORY_MAX: << parameters.history_max >>
+        HELM_BOOL_DEBUG: << parameters.debug >>
       command: <<include(scripts/upgrade_helm_chart.sh)>>
       no_output_timeout: << parameters.no_output_timeout >>

--- a/src/scripts/install_helm_chart.sh
+++ b/src/scripts/install_helm_chart.sh
@@ -3,6 +3,7 @@ HELM_STR_VALUES_TO_OVERRIDE="$(echo "${HELM_STR_VALUES_TO_OVERRIDE}" | circleci 
 HELM_STR_NAMESPACE="$(echo "${HELM_STR_NAMESPACE}" | circleci env subst)"
 HELM_STR_RELEASE_NAME="$(echo "${HELM_STR_RELEASE_NAME}" | circleci env subst)"
 HELM_STR_CHART="$(echo "${HELM_STR_CHART}" | circleci env subst)"
+HELM_STR_HISTORY_MAX="$(echo "${HELM_STR_HISTORY_MAX}" | circleci env subst)"
 
 set -x
 if [ -n "${HELM_STR_VALUES_TO_OVERRIDE}" ]; then
@@ -20,6 +21,9 @@ if [ -n "${HELM_STR_NAMESPACE}" ]; then
 fi
 if [ "${HELM_BOOL_WAIT}" -eq 1 ]; then
   set -- "$@" --wait
+fi
+if [ -n "${HELM_STR_HISTORY_MAX}" ]; then
+  set -- "$@" --history-max "${HELM_STR_HISTORY_MAX}"
 fi
 if [ -n "${HELM_STR_RELEASE_NAME}" ]; then
   helm install "${HELM_STR_RELEASE_NAME}" "${HELM_STR_CHART}" "$@"

--- a/src/scripts/install_helm_chart.sh
+++ b/src/scripts/install_helm_chart.sh
@@ -22,6 +22,9 @@ fi
 if [ "${HELM_BOOL_WAIT}" -eq 1 ]; then
   set -- "$@" --wait
 fi
+if [ "${HELM_BOOL_DEBUG}" -eq 1 ]; then
+  set -- "$@" --debug
+fi
 if [ -n "${HELM_STR_HISTORY_MAX}" ]; then
   set -- "$@" --history-max "${HELM_STR_HISTORY_MAX}"
 fi

--- a/src/scripts/install_helm_chart.sh
+++ b/src/scripts/install_helm_chart.sh
@@ -3,7 +3,6 @@ HELM_STR_VALUES_TO_OVERRIDE="$(echo "${HELM_STR_VALUES_TO_OVERRIDE}" | circleci 
 HELM_STR_NAMESPACE="$(echo "${HELM_STR_NAMESPACE}" | circleci env subst)"
 HELM_STR_RELEASE_NAME="$(echo "${HELM_STR_RELEASE_NAME}" | circleci env subst)"
 HELM_STR_CHART="$(echo "${HELM_STR_CHART}" | circleci env subst)"
-HELM_STR_HISTORY_MAX="$(echo "${HELM_STR_HISTORY_MAX}" | circleci env subst)"
 
 set -x
 if [ -n "${HELM_STR_VALUES_TO_OVERRIDE}" ]; then
@@ -24,9 +23,6 @@ if [ "${HELM_BOOL_WAIT}" -eq 1 ]; then
 fi
 if [ "${HELM_BOOL_DEBUG}" -eq 1 ]; then
   set -- "$@" --debug
-fi
-if [ -n "${HELM_STR_HISTORY_MAX}" ]; then
-  set -- "$@" --history-max "${HELM_STR_HISTORY_MAX}"
 fi
 if [ -n "${HELM_STR_RELEASE_NAME}" ]; then
   helm install "${HELM_STR_RELEASE_NAME}" "${HELM_STR_CHART}" "$@"

--- a/src/scripts/upgrade_helm_chart.sh
+++ b/src/scripts/upgrade_helm_chart.sh
@@ -60,8 +60,10 @@ if [ "${HELM_BOOL_FORCE}" -eq 1 ]; then
   set -- "$@" --force
 fi
 
-helm repo add "${HELM_STR_RELEASE_NAME}" "${HELM_STR_ADD_REPO}"
-helm repo update
+if [ -n "${HELM_STR_ADD_REPO}" ]; then
+  helm repo add "${HELM_STR_RELEASE_NAME}" "${HELM_STR_ADD_REPO}"
+  helm repo update
+fi
 
 helm upgrade --install "${HELM_STR_RELEASE_NAME}" "${HELM_STR_CHART}" "$@"
 set +x

--- a/src/scripts/upgrade_helm_chart.sh
+++ b/src/scripts/upgrade_helm_chart.sh
@@ -8,6 +8,7 @@ HELM_STR_VALUES_TO_OVERRIDE="$(echo "${HELM_STR_VALUES_TO_OVERRIDE}" | circleci 
 HELM_STR_CHART="$(echo "${HELM_STR_CHART}" | circleci env subst)"
 HELM_STR_RELEASE_NAME="$(echo "${HELM_STR_RELEASE_NAME}" | circleci env subst)"
 HELM_STR_ADD_REPO="$(echo "${HELM_STR_ADD_REPO}" | circleci env subst)"
+HELM_STR_HISTORY_MAX="$(echo "${HELM_STR_HISTORY_MAX}" | circleci env subst)"
 
 set -x
 if [ -n "${HELM_STR_NAMESPACE}" ]; then
@@ -58,6 +59,9 @@ if [ "${HELM_BOOL_WAIT_FOR_JOBS}" -eq 1 ]; then
 fi
 if [ "${HELM_BOOL_FORCE}" -eq 1 ]; then
   set -- "$@" --force
+fi
+if [ -n "${HELM_STR_HISTORY_MAX}" ]; then
+  set -- "$@" --history-max "${HELM_STR_HISTORY_MAX}"
 fi
 
 if [ -n "${HELM_STR_ADD_REPO}" ]; then

--- a/src/scripts/upgrade_helm_chart.sh
+++ b/src/scripts/upgrade_helm_chart.sh
@@ -8,7 +8,6 @@ HELM_STR_VALUES_TO_OVERRIDE="$(echo "${HELM_STR_VALUES_TO_OVERRIDE}" | circleci 
 HELM_STR_CHART="$(echo "${HELM_STR_CHART}" | circleci env subst)"
 HELM_STR_RELEASE_NAME="$(echo "${HELM_STR_RELEASE_NAME}" | circleci env subst)"
 HELM_STR_ADD_REPO="$(echo "${HELM_STR_ADD_REPO}" | circleci env subst)"
-HELM_STR_HISTORY_MAX="$(echo "${HELM_STR_HISTORY_MAX}" | circleci env subst)"
 
 set -x
 if [ -n "${HELM_STR_NAMESPACE}" ]; then
@@ -62,9 +61,6 @@ if [ "${HELM_BOOL_FORCE}" -eq 1 ]; then
 fi
 if [ "${HELM_BOOL_DEBUG}" -eq 1 ]; then
   set -- "$@" --debug
-fi
-if [ -n "${HELM_STR_HISTORY_MAX}" ]; then
-  set -- "$@" --history-max "${HELM_STR_HISTORY_MAX}"
 fi
 
 if [ -n "${HELM_STR_ADD_REPO}" ]; then

--- a/src/scripts/upgrade_helm_chart.sh
+++ b/src/scripts/upgrade_helm_chart.sh
@@ -60,6 +60,9 @@ fi
 if [ "${HELM_BOOL_FORCE}" -eq 1 ]; then
   set -- "$@" --force
 fi
+if [ "${HELM_BOOL_DEBUG}" -eq 1 ]; then
+  set -- "$@" --debug
+fi
 if [ -n "${HELM_STR_HISTORY_MAX}" ]; then
   set -- "$@" --history-max "${HELM_STR_HISTORY_MAX}"
 fi


### PR DESCRIPTION
This `PR` contains breaking changes and updates the following: 

`upgrade_helm_chart` command 
- remove `update_repositories` parameter in favor of adding validation using `add_repo`
- add validation to run `helm repo update` cli command if a `add_repo` parameter is not empty
- add `debug` parameter

`install_helm_client`
- remove `stable_repo_url` since this is only required for `helm 2` which has been deprecated. 

`install_helm_chart` command
- add `debug` parameter