### PR TITLE
Add `history_max` parameter to `upgrade_helm_chart` command

### DIFF
--- a/src/commands/upgrade_helm_chart.yml
+++ b/src/commands/upgrade_helm_chart.yml
@@ -99,6 +99,11 @@ parameters:
       command. Format: key1=val1,key2=val2
     type: string
     default: ""
+  history_max:
+    description: |
+      limit the maximum number of revisions saved per release. Use 0 for no limit (default 10)
+    type: integer
+    default: 10
   helm_version:
     type: string
     default: "v3.8.2"
@@ -140,6 +145,7 @@ steps:
         HELM_STR_VALUES: << parameters.values >>
         HELM_STR_VERSION: << parameters.version >>
         HELM_STR_VALUES_TO_OVERRIDE: << parameters.values_to_override >>
+        HELM_INT_HISTORY_MAX: << parameters.history_max >>
         HELM_STR_CHART: << parameters.chart >>
         HELM_STR_RELEASE_NAME: << parameters.release_name >>
         HELM_STR_ADD_REPO: << parameters.add_repo >>

--- a/src/scripts/upgrade_helm_chart.sh
+++ b/src/scripts/upgrade_helm_chart.sh
@@ -50,6 +50,9 @@ fi
 if [ -n "${HELM_STR_VALUES_TO_OVERRIDE}" ]; then
   set -- "$@" --set "${HELM_STR_VALUES_TO_OVERRIDE}"
 fi
+if [ -n "${HELM_INT_HISTORY_MAX}" ]; then
+  set -- "$@" --history-max "${HELM_INT_HISTORY_MAX}"
+fi
 if [ -n "${HELM_STR_VERSION}" ]; then
   set -- "$@" --version="${HELM_STR_VERSION}"
 fi


### PR DESCRIPTION
**Note: I have not tested this as I have not looked into how to use my forked orb in my CircleCI builds**

### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [X] All new jobs, commands, executors, parameters have descriptions
- [X] Examples have been added for any significant new features
- [X] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

Add `history_max` parameter to `upgrade_helm_chart` command, as requested in GH-63

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

Add `history_max` parameter to `upgrade_helm_chart` command, as requested in GH-63