### PR TITLE
Ensure `install_helm_client` doesn't leave files CWD

### DIFF
--- a/src/scripts/install_helm_client.sh
+++ b/src/scripts/install_helm_client.sh
@@ -16,4 +16,6 @@ INSTALL_SCRIPT="https://raw.githubusercontent.com/helm/helm/master/scripts/get-h
 curl "${INSTALL_SCRIPT}" > get_helm.sh
 chmod 700 get_helm.sh
 ./get_helm.sh "$@"
+
+rm -rf get_helm.sh
 set +x


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

We happened to be running the `install_helm_client` in a Job before `checkout`, which caused `checkout` to fail as CWD was no longer an empty directory.

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

This changes `install_helm_client` to cleanup the `get_helm.sh` script after it's done.