### PR TITLE
Feat/retry install client

### DIFF
--- a/src/commands/install_helm_client.yml
+++ b/src/commands/install_helm_client.yml
@@ -8,10 +8,15 @@ parameters:
     type: string
     default: "v3.8.2"
     description: the helm client version to install. e.g. v3.8.0
+  retries:
+    type: string
+    default: 2
+    description: The amount of retries when downloading the helm client, in case it fails.
 
 steps:
   - run:
       name: Install and init the helm client (if necessary)
       environment:
+        HELM_RETRIES: <<parameters.retries>>
         HELM_STR_VERSION: << parameters.version >>
       command: <<include(scripts/install_helm_client.sh)>>

--- a/src/commands/install_helm_client.yml
+++ b/src/commands/install_helm_client.yml
@@ -9,7 +9,7 @@ parameters:
     default: "v3.8.2"
     description: the helm client version to install. e.g. v3.8.0
   retries:
-    type: string
+    type: integer
     default: 2
     description: The amount of retries when downloading the helm client, in case it fails.
 

--- a/src/scripts/install_helm_client.sh
+++ b/src/scripts/install_helm_client.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 HELM_STR_VERSION="$(echo "${HELM_STR_VERSION}" | circleci env subst)"
+HELM_RETRIES="$(echo "${HELM_RETRIES}" | circleci env subst)"
 
 set -x
 if command -v helm &> /dev/null; then
@@ -13,7 +14,24 @@ fi
 
 INSTALL_SCRIPT="https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3"
 
-curl "${INSTALL_SCRIPT}" > get_helm.sh
+success_helm_download=false
+retry_count=0
+while [ "$retry_count" -lt "$HELM_RETRIES" ]; do
+  curl -sSf "${INSTALL_SCRIPT}" -o get_helm.sh
+  if [ $? -eq 0 ]; then
+    echo "Script downloaded succesfully"
+    success_helm_download=true
+    break
+  else
+    echo "Error downloading. Retying..."
+    retry_count=$((rety_count + 1))
+    sleep 5
+  fi
+done
+if [ "$success_helm_download" = false ]; then
+  echo "Max retries reached"
+  exit 1
+fi
 chmod 700 get_helm.sh
 ./get_helm.sh "$@"
 

--- a/src/scripts/install_helm_client.sh
+++ b/src/scripts/install_helm_client.sh
@@ -23,7 +23,7 @@ while [ "$retry_count" -lt "$HELM_RETRIES" ]; do
     break
   else
     echo "Error downloading. Retying..."
-    retry_count=$((rety_count + 1))
+    retry_count=$((retry_count + 1))
     sleep 5
   fi
 done

--- a/src/scripts/install_helm_client.sh
+++ b/src/scripts/install_helm_client.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 HELM_STR_VERSION="$(echo "${HELM_STR_VERSION}" | circleci env subst)"
-HELM_RETRIES="$(echo "${HELM_RETRIES}" | circleci env subst)"
 
 set -x
 if command -v helm &> /dev/null; then

--- a/src/scripts/install_helm_client.sh
+++ b/src/scripts/install_helm_client.sh
@@ -16,8 +16,8 @@ INSTALL_SCRIPT="https://raw.githubusercontent.com/helm/helm/master/scripts/get-h
 success_helm_download=false
 retry_count=0
 while [ "$retry_count" -lt "$HELM_RETRIES" ]; do
-  curl -sSf "${INSTALL_SCRIPT}" -o get_helm.sh
-  if [ $? -eq 0 ]; then
+  
+  if curl -sSf "${INSTALL_SCRIPT}" -o get_helm.sh; then
     echo "Script downloaded succesfully"
     success_helm_download=true
     break


### PR DESCRIPTION
Add a retry process to the download of the helm client. It defaults to 2 retires, and can be changed through a parameter.
Resolves #62