### PR TITLE
Add empty value as default for add_repo

### DIFF
--- a/src/commands/install_helm_chart.yml
+++ b/src/commands/install_helm_chart.yml
@@ -14,8 +14,9 @@ parameters:
   add_repo:
     description: |
       The url for the helm chart repository used as part of helm repo add
-      command
+      command. Required when update_repositories is true.
     type: string
+    default: ""
   release_name:
     description: |
       Specify a name for the release.


### PR DESCRIPTION
Add_repo is only used when update_repositories is true, so this value shouldn't be enforced to be passed.
This resolves #84 