### PR TITLE
feat!: bump default Helm version v3.8.2 → v4.2.0 (PIE-6)

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -32,10 +32,18 @@ jobs:
         type: string
       helm_plugin_url:
         type: string
+      gpg_key_url:
+        default: ""
+        type: string
+      skip_verify:
+        default: false
+        type: boolean
     steps:
       - helm/install_helm_plugin:
           helm_plugin_url: << parameters.helm_plugin_url >>
-          plugin_version: <<parameters.plugin_version>>
+          plugin_version: << parameters.plugin_version >>
+          gpg_key_url: << parameters.gpg_key_url >>
+          skip_verify: << parameters.skip_verify >>
   install-helm-on-eks-cluster:
     docker:
       - image: cimg/python:3.10
@@ -180,11 +188,12 @@ workflows:
       - helm-plugin-install-test:
           name: helm-plugin-install-env
           helm_plugin_url: https://github.com/adamreese/helm-env
+          skip_verify: true
           filters: *filters
       - helm-plugin-install-test:
           name: helm-plugin-install-secrets
-          helm_plugin_url: https://github.com/jkroepke/helm-secrets
-          plugin_version: v4.6.0 
+          helm_plugin_url: https://github.com/jkroepke/helm-secrets/releases/download/v4.7.6/secrets-4.7.6.tgz
+          gpg_key_url: https://github.com/jkroepke.gpg
           filters: *filters
       - aws-eks/create-cluster:
           name: create-cluster-helm4

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -79,7 +79,7 @@ jobs:
         description: the helm chart to install
       debug:
         description: |
-          Enable debug mode 
+          Enable debug mode
         type: boolean
         default: false
     steps:

--- a/src/commands/delete_helm_release.yml
+++ b/src/commands/delete_helm_release.yml
@@ -71,7 +71,7 @@ parameters:
     default: ""
   helm_version:
     type: string
-    default: "v3.8.2"
+    default: "v4.2.0"
     description: the helm client version to install. e.g. v3.0.0.
   no_output_timeout:
     description: |

--- a/src/commands/install_helm_chart.yml
+++ b/src/commands/install_helm_chart.yml
@@ -55,7 +55,7 @@ parameters:
     default: true
   helm_version:
     type: string
-    default: "v3.8.2"
+    default: "v4.2.0"
     description: the helm client version to install. e.g. v3.0.0
   no_output_timeout:
     description: |

--- a/src/commands/install_helm_client.yml
+++ b/src/commands/install_helm_client.yml
@@ -6,7 +6,7 @@ description: |
 parameters:
   version:
     type: string
-    default: "v3.8.2"
+    default: "v4.2.0"
     description: the helm client version to install. e.g. v3.8.0
   retries:
     type: integer

--- a/src/commands/install_helm_plugin.yml
+++ b/src/commands/install_helm_plugin.yml
@@ -28,16 +28,38 @@ parameters:
     type: boolean
     description: Whether or not to install the helm client. Defaults to true.
     default: true
+  skip_verify:
+    type: boolean
+    default: false
+    description: |
+      Pass --verify=false to helm plugin install. Set to true only for plugin
+      sources that do not provide GPG-signed provenance files. Helm 4 verifies
+      plugins by default; prefer using gpg_key_url for plugins that support it.
+  gpg_key_url:
+    type: string
+    default: ""
+    description: |
+      URL of the GPG public key to import before installing the plugin. Use this
+      for plugins that provide signed provenance files (e.g. set to
+      https://github.com/jkroepke.gpg for helm-secrets). Leave empty when
+      skip_verify is true or when the keyring is already configured.
 steps:
   - when:
       condition: << parameters.install_helm_client >>
       steps:
         - install_helm_client:
             version: << parameters.helm_version >>
+  - when:
+      condition: << parameters.gpg_key_url >>
+      steps:
+        - run:
+            name: Import GPG key for plugin verification
+            command: curl -fsSL "<< parameters.gpg_key_url >>" | gpg --import
   - run:
       name: Install helm plugin
       environment:
         HELM_STR_PLUGIN_URL: << parameters.helm_plugin_url >>
         HELM_STR_PLUGIN_VERSION: << parameters.plugin_version >>
+        HELM_BOOL_SKIP_VERIFY: << parameters.skip_verify >>
       command: <<include(scripts/install_helm_plugin.sh)>>
       no_output_timeout: << parameters.no_output_timeout >>

--- a/src/commands/install_helm_plugin.yml
+++ b/src/commands/install_helm_plugin.yml
@@ -54,12 +54,28 @@ steps:
       steps:
         - run:
             name: Import GPG key for plugin verification
-            command: curl -fsSL "<< parameters.gpg_key_url >>" | gpg --import
-  - run:
-      name: Install helm plugin
-      environment:
-        HELM_STR_PLUGIN_URL: << parameters.helm_plugin_url >>
-        HELM_STR_PLUGIN_VERSION: << parameters.plugin_version >>
-        HELM_BOOL_SKIP_VERIFY: << parameters.skip_verify >>
-      command: <<include(scripts/install_helm_plugin.sh)>>
-      no_output_timeout: << parameters.no_output_timeout >>
+            command: |
+              curl -fsSL "<< parameters.gpg_key_url >>" | gpg --import
+              gpg --export > ~/.gnupg/pubring.gpg
+  - when:
+      condition: << parameters.skip_verify >>
+      steps:
+        - run:
+            name: Install helm plugin
+            environment:
+              HELM_STR_PLUGIN_URL: << parameters.helm_plugin_url >>
+              HELM_STR_PLUGIN_VERSION: << parameters.plugin_version >>
+              HELM_BOOL_SKIP_VERIFY: "true"
+            command: <<include(scripts/install_helm_plugin.sh)>>
+            no_output_timeout: << parameters.no_output_timeout >>
+  - unless:
+      condition: << parameters.skip_verify >>
+      steps:
+        - run:
+            name: Install helm plugin
+            environment:
+              HELM_STR_PLUGIN_URL: << parameters.helm_plugin_url >>
+              HELM_STR_PLUGIN_VERSION: << parameters.plugin_version >>
+              HELM_BOOL_SKIP_VERIFY: "false"
+            command: <<include(scripts/install_helm_plugin.sh)>>
+            no_output_timeout: << parameters.no_output_timeout >>

--- a/src/commands/install_helm_plugin.yml
+++ b/src/commands/install_helm_plugin.yml
@@ -10,7 +10,7 @@ parameters:
     type: string
   helm_version:
     type: string
-    default: "v3.8.2"
+    default: "v4.2.0"
     description: the helm client version to install. e.g. v3.0.0
   no_output_timeout:
     description: |

--- a/src/commands/upgrade_helm_chart.yml
+++ b/src/commands/upgrade_helm_chart.yml
@@ -106,7 +106,7 @@ parameters:
     default: 10
   helm_version:
     type: string
-    default: "v3.8.2"
+    default: "v4.2.0"
     description: the helm client version to install. e.g. v3.0.0
   no_output_timeout:
     description: |

--- a/src/examples/install_helm_chart_with_helm3.yml
+++ b/src/examples/install_helm_chart_with_helm3.yml
@@ -20,7 +20,7 @@ usage:
         - aws-eks/update-kubeconfig-with-authenticator:
             cluster-name: << parameters.cluster-name >>
         - helm/install_helm_chart:
-            helm_version: v3.2.4
+            helm_version: v4.2.0
             chart: stable/grafana
             release_name: grafana-release
     delete_helm_release:
@@ -33,7 +33,7 @@ usage:
         - aws-eks/update-kubeconfig-with-authenticator:
             cluster-name: << parameters.cluster-name >>
         - helm/delete_helm_release:
-            helm_version: v3.2.4
+            helm_version: v4.2.0
             release_name: grafana-release
             timeout: 600s
 

--- a/src/scripts/install_helm_plugin.sh
+++ b/src/scripts/install_helm_plugin.sh
@@ -2,11 +2,17 @@
 HELM_STR_PLUGIN_URL="$(echo "${HELM_STR_PLUGIN_URL}" | circleci env subst)"
 HELM_STR_PLUGIN_VERSION="$(echo "${HELM_STR_PLUGIN_VERSION}" | circleci env subst)"
 
+INSTALL_ARGS=("${HELM_STR_PLUGIN_URL}")
+
 if [ -n "$HELM_STR_PLUGIN_VERSION" ]; then
-  STATUS="$(helm plugin install "${HELM_STR_PLUGIN_URL}" --version "${HELM_STR_PLUGIN_VERSION}")"
-else
-  STATUS="$(helm plugin install "${HELM_STR_PLUGIN_URL}")"
+  INSTALL_ARGS+=("--version" "${HELM_STR_PLUGIN_VERSION}")
 fi
+
+if [ "${HELM_BOOL_SKIP_VERIFY}" = "true" ]; then
+  INSTALL_ARGS+=("--verify=false")
+fi
+
+STATUS="$(helm plugin install "${INSTALL_ARGS[@]}")"
 
 if echo "${STATUS}" | grep "Installed plugin:"; then
   echo "Installation successful"


### PR DESCRIPTION
## Summary

- Bumps the `version` parameter default in `commands/install_helm_client.yml` from `v3.8.2` to `v4.2.0`
- v3.8.2 was released April 2022; v4.2.0 is the latest Helm stable release.
- Adds Helm 4 plugin verification support to `install_helm_plugin`:
  - New `skip_verify` param (default `false`) — passes `--verify=false` for plugins without GPG-signed provenance files
  - New `gpg_key_url` param — imports a GPG public key before installation, enabling fully verified installs for plugins that ship `.prov` files
  - Updates `helm-secrets` test to v4.7.6 via direct tarball URL with GPG key import (Helm 4 can only verify tarball-URL installs, not GitHub repo URLs)
  - Sets `skip_verify: true` for `helm-env` (unmaintained plugin with no provenance support)

## Breaking change

Users who relied on the `v3.8.2` default without pinning an explicit \`version\` will now get Helm v4.2.0.

## Migration guide (v→v+1)

```yaml
# Pin the old version to keep it:
- helm/install_helm_client:
    version: "v3.8.2"
```

Closes PIE-6